### PR TITLE
Drop epochNo column from Block table

### DIFF
--- a/cardano-explorer-core/src/Explorer/Core/DB/Migration.hs
+++ b/cardano-explorer-core/src/Explorer/Core/DB/Migration.hs
@@ -145,7 +145,7 @@ createMigration (MigrationDir migdir) = do
         , "  END IF ;\n"
         , "END ;\n"
         , "$$ LANGUAGE plpgsql ;\n\n"
-        , "SELECT migrate() ; \n\n"
+        , "SELECT migrate() ;\n\n"
         , "DROP FUNCTION migrate() ;\n"
         ]
 
@@ -157,9 +157,11 @@ createMigration (MigrationDir migdir) = do
       res <- selectFirst [] []
       case res of
         Nothing -> error "getSchemaVersion failed!"
-        Just x ->
-          let (SchemaVersion stage ver date) = entityVal x
-          in pure $ MigrationVersion stage ver date
+        Just x -> do
+          -- Only interested in the stage2 version because that is the only stage for
+          -- which Persistent migrations are generated.
+          let (SchemaVersion _ stage2 _) = entityVal x
+          pure $ MigrationVersion 2 stage2 0
 
 -- Mainly for tests.
 runDbAction :: ReaderT SqlBackend (NoLoggingT IO) a -> IO a

--- a/cardano-explorer-core/src/Explorer/Core/DB/Migration/Version.hs
+++ b/cardano-explorer-core/src/Explorer/Core/DB/Migration/Version.hs
@@ -33,13 +33,12 @@ parseMigrationVersionFromFile str =
     _ -> Nothing
 
 nextMigrationVersion :: MigrationVersion -> IO MigrationVersion
-nextMigrationVersion (MigrationVersion stage ver _) = do
+nextMigrationVersion (MigrationVersion _stage ver _date) = do
   -- We can ignore the provided 'stage' and 'date' fields, but we do bump the version number.
   -- All new versions have 'stage == 2' because the stage 2 migrations are the Presistent
   -- generated ones. For the date we use today's date.
-  let nextVersion = if stage /= 2 then 1 else ver + 1
   (y, m, d) <- Time.toGregorian . Time.utctDay <$> Time.getCurrentTime
-  pure $ MigrationVersion 2 (nextVersion) (fromIntegral y * 10000 + m * 100 + d)
+  pure $ MigrationVersion 2 (ver + 1) (fromIntegral y * 10000 + m * 100 + d)
 
 renderMigrationVersion :: MigrationVersion -> String
 renderMigrationVersion mv =

--- a/cardano-explorer-core/src/Explorer/Core/DB/Schema.hs
+++ b/cardano-explorer-core/src/Explorer/Core/DB/Schema.hs
@@ -45,13 +45,12 @@ share [mkPersist sqlSettings, mkMigrate "migrateExplorerDB"] [persistLowerCase|
   -- primary key Haskell type can be used in a type-safe way in the rest
   -- of the schema definition.
   Block
-    hash                ByteString      sqltype=hashtype
-    epochNo             Word64          sqltype=uinteger
-    slotNo              Word64 Maybe    sqltype=uinteger
-    blockNo             Word64          sqltype=uinteger
-    previous            BlockId Maybe   sqltype=hashtype
-    merkelRoot          ByteString      sqltype=hashtype
-    size                Word64          sqltype=uinteger
+    hash                ByteString          sqltype=hashtype
+    slotNo              Word64 Maybe        sqltype=uinteger
+    blockNo             Word64              sqltype=uinteger
+    previous            BlockId Maybe       sqltype=hashtype
+    merkelRoot          ByteString Maybe    sqltype=hashtype
+    size                Word64              sqltype=uinteger
     UniqueBlock         hash
 
   Tx

--- a/cardano-explorer-core/test/test-db.hs
+++ b/cardano-explorer-core/test/test-db.hs
@@ -60,13 +60,24 @@ insertFirstTest =
 
 
 blockZero :: Block
-blockZero = Block (mkHash '\0') 0 Nothing 0 Nothing merkelHash 42
+blockZero = Block (mkHash '\0') Nothing 0 Nothing Nothing 42
 
 blockOne :: Block
-blockOne = Block (mkHash '\1') 0 (Just 0) 1 Nothing merkelHash 42
+blockOne = Block (mkHash '\1') (Just 0) 1 Nothing (Just merkelHash) 42
 
 mkHash :: Char -> ByteString
 mkHash = BS.pack . replicate 32
 
 merkelHash :: ByteString
 merkelHash = BS.pack $ replicate 32 'a'
+
+{-
+  Block
+    hash                ByteString          sqltype=hashtype
+    slotNo              Word64 Maybe        sqltype=uinteger
+    blockNo             Word64              sqltype=uinteger
+    previous            BlockId Maybe       sqltype=hashtype
+    merkelRoot          ByteString Maybe    sqltype=hashtype
+    size                Word64              sqltype=uinteger
+    UniqueBlock         hash
+-}

--- a/schema/migration-2-0002-20190813.sql
+++ b/schema/migration-2-0002-20190813.sql
@@ -1,0 +1,20 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 2 THEN
+    EXECUTE 'ALTER TABLE "block" ALTER COLUMN "merkel_root" DROP NOT NULL' ;
+    EXECUTE 'ALTER TABLE "block" DROP COLUMN "epoch_no"' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = 2 ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
The old `cardano-sl` code base had a type which was basically a  `(epoch, slotInEpoch)` pair, while the new `cardano-ledger` data types  just have a raw flat `slotNumber` field.
    
Therefore we drop the `epochNo` column from the 'Block' table, in favor of the flat slot number from the `cardano-ledger` types. The  `(epoch, slotInEpoch)` pair can be recovered from that using a `divMod` operation.
