### PR TITLE
Schema udpates

### DIFF
--- a/cardano-explorer-core/src/Explorer/Core/DB/Schema.hs
+++ b/cardano-explorer-core/src/Explorer/Core/DB/Schema.hs
@@ -45,16 +45,16 @@ share [mkPersist sqlSettings, mkMigrate "migrateExplorerDB"] [persistLowerCase|
   -- primary key Haskell type can be used in a type-safe way in the rest
   -- of the schema definition.
   Block
-    hash                ByteString          sqltype=hashtype
+    hash                ByteString          sqltype=hash32type
     slotNo              Word64 Maybe        sqltype=uinteger
     blockNo             Word64              sqltype=uinteger
-    previous            BlockId Maybe       sqltype=hashtype
-    merkelRoot          ByteString Maybe    sqltype=hashtype
+    previous            BlockId Maybe
+    merkelRoot          ByteString Maybe    sqltype=hash32type
     size                Word64              sqltype=uinteger
     UniqueBlock         hash
 
   Tx
-    hash                ByteString      sqltype=hashtype
+    hash                ByteString      sqltype=hash32type
     block               BlockId         -- This type is the primary key for the 'block' table.
     fee                 Word64          sqltype=lovelace
     UniqueTx            hash
@@ -62,14 +62,13 @@ share [mkPersist sqlSettings, mkMigrate "migrateExplorerDB"] [persistLowerCase|
   TxOut
     txId                TxId            -- This type is the primary key for the 'tx' table.
     index               Word16          sqltype=txindex
-    address             ByteString      sqltype=hashtype
+    address             ByteString      sqltype=hash28type
     value               Word64          sqltype=lovelace
     UniqueTxout         txId index      -- The (tx_id, index) pair must be unique.
 
   TxIn
     txId                TxId            -- This type is the primary key for the 'tx' table.
     index               Word16          sqltype=txindex
-    txOutId             TxOutId         -- This type is the primary key for the 'txout' table.
     UniqueTxin          txId index      -- The (tx_id, index) pair must be unique.
 
   |]

--- a/schema/migration-1-0002-20190816.sql
+++ b/schema/migration-1-0002-20190816.sql
@@ -1,0 +1,29 @@
+-- Hand written migration to create the custom types with 'DOMAIN' statements.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+
+DECLARE
+  next_version int;
+
+BEGIN
+  SELECT stage_one + 1 INTO next_version FROM "schema_version";
+  IF next_version = 2 THEN
+    -- Blocks, transactions and merkel roots use a 32 byte hash.
+    EXECUTE 'CREATE DOMAIN hash32type AS bytea CHECK (octet_length (VALUE) = 32);';
+    -- Addresses use a 28 byte hash.
+    EXECUTE 'CREATE DOMAIN hash28type AS bytea CHECK (octet_length (VALUE) = 28);';
+
+	-- Drop this view if because this migration changes types of columns the view
+	-- referred to. We can recreate the view later in the migration schedule.
+    EXECUTE 'DROP VIEW IF EXISTS utxo;';
+
+    UPDATE "schema_version" SET stage_one = 2;
+    RAISE NOTICE 'DB has been migrated to stage_one version %', next_version;
+  END IF;
+END;
+
+$$ LANGUAGE plpgsql;
+
+SELECT migrate();
+
+DROP FUNCTION migrate();

--- a/schema/migration-2-0003-20190816.sql
+++ b/schema/migration-2-0003-20190816.sql
@@ -1,0 +1,23 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 3 THEN
+    EXECUTE 'ALTER TABLE "block" ALTER COLUMN "hash" TYPE hash32type' ;
+    EXECUTE 'ALTER TABLE "block" ALTER COLUMN "merkel_root" TYPE hash32type' ;
+    EXECUTE 'ALTER TABLE "tx" ALTER COLUMN "hash" TYPE hash32type' ;
+    EXECUTE 'ALTER TABLE "tx_out" ALTER COLUMN "address" TYPE hash28type' ;
+    EXECUTE 'ALTER TABLE "tx_in" DROP COLUMN "tx_out_id"' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = 3 ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;

--- a/schema/migration-3-0001-20190816.sql
+++ b/schema/migration-3-0001-20190816.sql
@@ -8,7 +8,7 @@ BEGIN
   IF next_version = 1 THEN
     -- TODO: Is there a way to avoid 'NOT IN' using an 'OUTER JOIN'?
     -- Does the 'OUTER JOIN' actually perform better?
-    EXECUTE 'CREATe VIEW utxo AS SELECT * FROM tx_out WHERE tx_out.id NOT IN (SELECT tx_out_id FROM tx_in)' ;
+    EXECUTE 'CREATe VIEW utxo AS SELECT tx_out.* FROM tx_out LEFT OUTER JOIN tx_in ON tx_out.tx_id = tx_in.tx_id AND tx_out.index = tx_in.index WHERE tx_in.tx_id IS NOT NULL' ;
 
     UPDATE schema_version SET stage_three = 1;
     RAISE NOTICE 'DB has been migrated to stage_three version %', next_version ;


### PR DESCRIPTION
* Update DOMAIN types because addresses are 28 bytes whereas the other hashes are 32 bytes.
* Drop the 'txOutId' field of the 'TxIn' table.
* Use a 'LEFT OUTER JOIN' to create the 'utxo' view table.