### PR TITLE
Re-introduce database transactions

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -171,3 +171,25 @@ source-repository-package
   location: https://github.com/input-output-hk/ouroboros-network
   tag: da6da94d26e72551e591eabfce99b01c7c70933c
   subdir: typed-protocols-cbor
+
+
+-- Keep these until this is merged https://github.com/yesodweb/persistent/pull/950
+-- and a new version is released.
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/persistent
+  tag: c85c1b3eabd81251beb0e358257a9e97c0e3c888
+  subdir: persistent
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/persistent
+  tag: c85c1b3eabd81251beb0e358257a9e97c0e3c888
+  subdir: persistent-postgresql
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/persistent
+  tag: c85c1b3eabd81251beb0e358257a9e97c0e3c888
+  subdir: persistent-template

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -11,9 +11,6 @@
         "esqueleto" = (((hackage.esqueleto)."3.0.0").revisions).default;
         "generic-monoid" = (((hackage.generic-monoid)."0.1.0.0").revisions).default;
         "libsystemd-journal" = (((hackage.libsystemd-journal)."1.4.4").revisions).default;
-        "persistent" = (((hackage.persistent)."2.10.0").revisions).default;
-        "persistent-postgresql" = (((hackage.persistent-postgresql)."2.10.0").revisions).default;
-        "persistent-template" = (((hackage.persistent-template)."2.7.2").revisions).default;
         "prometheus" = (((hackage.prometheus)."2.1.2").revisions).default;
         "pvss" = (((hackage.pvss)."0.2.0").revisions).default;
         "tasty-hedgehog" = (((hackage.tasty-hedgehog)."1.0.0.1").revisions).default;
@@ -51,6 +48,9 @@
         ouroboros-consensus = ./ouroboros-consensus.nix;
         typed-protocols = ./typed-protocols.nix;
         typed-protocols-cbor = ./typed-protocols-cbor.nix;
+        persistent = ./persistent.nix;
+        persistent-postgresql = ./persistent-postgresql.nix;
+        persistent-template = ./persistent-template.nix;
         cardano-crypto = ./cardano-crypto.nix;
         };
       compiler.version = "8.6.5";

--- a/nix/.stack.nix/persistent-postgresql.nix
+++ b/nix/.stack.nix/persistent-postgresql.nix
@@ -1,0 +1,75 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "persistent-postgresql"; version = "2.10.0"; };
+      license = "MIT";
+      copyright = "";
+      maintainer = "Michael Snoyman <michael@snoyman.com>";
+      author = "Felipe Lessa, Michael Snoyman <michael@snoyman.com>";
+      homepage = "http://www.yesodweb.com/book/persistent";
+      url = "";
+      synopsis = "Backend for the persistent library using postgresql.";
+      description = "Based on the postgresql-simple package";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.persistent)
+          (hsPkgs.aeson)
+          (hsPkgs.blaze-builder)
+          (hsPkgs.bytestring)
+          (hsPkgs.conduit)
+          (hsPkgs.containers)
+          (hsPkgs.monad-logger)
+          (hsPkgs.postgresql-simple)
+          (hsPkgs.postgresql-libpq)
+          (hsPkgs.resourcet)
+          (hsPkgs.resource-pool)
+          (hsPkgs.text)
+          (hsPkgs.time)
+          (hsPkgs.transformers)
+          (hsPkgs.unliftio-core)
+          ];
+        };
+      tests = {
+        "test" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.persistent)
+            (hsPkgs.persistent-postgresql)
+            (hsPkgs.persistent-qq)
+            (hsPkgs.persistent-template)
+            (hsPkgs.persistent-test)
+            (hsPkgs.aeson)
+            (hsPkgs.bytestring)
+            (hsPkgs.containers)
+            (hsPkgs.fast-logger)
+            (hsPkgs.HUnit)
+            (hsPkgs.hspec)
+            (hsPkgs.hspec-expectations)
+            (hsPkgs.monad-logger)
+            (hsPkgs.QuickCheck)
+            (hsPkgs.quickcheck-instances)
+            (hsPkgs.resourcet)
+            (hsPkgs.text)
+            (hsPkgs.time)
+            (hsPkgs.transformers)
+            (hsPkgs.unliftio-core)
+            (hsPkgs.unordered-containers)
+            (hsPkgs.vector)
+            ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/persistent";
+      rev = "c85c1b3eabd81251beb0e358257a9e97c0e3c888";
+      sha256 = "1flszbqkmm9rgrd9qgfm2689hs0i40lw34ll6djpwjvy4v9fyldl";
+      });
+    postUnpack = "sourceRoot+=/persistent-postgresql; echo source root reset to \$sourceRoot";
+    }

--- a/nix/.stack.nix/persistent-template.nix
+++ b/nix/.stack.nix/persistent-template.nix
@@ -1,0 +1,72 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "persistent-template"; version = "2.7.2"; };
+      license = "MIT";
+      copyright = "";
+      maintainer = "Michael Snoyman <michael@snoyman.com>, Greg Weber <greg@gregweber.info>";
+      author = "Michael Snoyman <michael@snoyman.com>";
+      homepage = "http://www.yesodweb.com/book/persistent";
+      url = "";
+      synopsis = "Type-safe, non-relational, multi-backend persistence.";
+      description = "Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/persistent-template>.";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.persistent)
+          (hsPkgs.aeson)
+          (hsPkgs.bytestring)
+          (hsPkgs.containers)
+          (hsPkgs.http-api-data)
+          (hsPkgs.monad-control)
+          (hsPkgs.monad-logger)
+          (hsPkgs.path-pieces)
+          (hsPkgs.template-haskell)
+          (hsPkgs.text)
+          (hsPkgs.transformers)
+          (hsPkgs.unordered-containers)
+          ];
+        };
+      tests = {
+        "test" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.persistent)
+            (hsPkgs.persistent-template)
+            (hsPkgs.aeson)
+            (hsPkgs.bytestring)
+            (hsPkgs.hspec)
+            (hsPkgs.QuickCheck)
+            (hsPkgs.text)
+            ];
+          };
+        };
+      benchmarks = {
+        "persistent-th-bench" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.persistent)
+            (hsPkgs.persistent-template)
+            (hsPkgs.criterion)
+            (hsPkgs.deepseq)
+            (hsPkgs.deepseq-generics)
+            (hsPkgs.file-embed)
+            (hsPkgs.text)
+            (hsPkgs.template-haskell)
+            ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/persistent";
+      rev = "c85c1b3eabd81251beb0e358257a9e97c0e3c888";
+      sha256 = "1flszbqkmm9rgrd9qgfm2689hs0i40lw34ll6djpwjvy4v9fyldl";
+      });
+    postUnpack = "sourceRoot+=/persistent-template; echo source root reset to \$sourceRoot";
+    }

--- a/nix/.stack.nix/persistent.nix
+++ b/nix/.stack.nix/persistent.nix
@@ -1,0 +1,76 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { nooverlap = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "persistent"; version = "2.10.2"; };
+      license = "MIT";
+      copyright = "";
+      maintainer = "Michael Snoyman <michael@snoyman.com>, Greg Weber <greg@gregweber.info>";
+      author = "Michael Snoyman <michael@snoyman.com>";
+      homepage = "http://www.yesodweb.com/book/persistent";
+      url = "";
+      synopsis = "Type-safe, multi-backend data serialization.";
+      description = "Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/persistent>.";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.aeson)
+          (hsPkgs.attoparsec)
+          (hsPkgs.base64-bytestring)
+          (hsPkgs.blaze-html)
+          (hsPkgs.bytestring)
+          (hsPkgs.conduit)
+          (hsPkgs.containers)
+          (hsPkgs.fast-logger)
+          (hsPkgs.http-api-data)
+          (hsPkgs.monad-logger)
+          (hsPkgs.mtl)
+          (hsPkgs.path-pieces)
+          (hsPkgs.resource-pool)
+          (hsPkgs.resourcet)
+          (hsPkgs.scientific)
+          (hsPkgs.silently)
+          (hsPkgs.template-haskell)
+          (hsPkgs.text)
+          (hsPkgs.time)
+          (hsPkgs.transformers)
+          (hsPkgs.unliftio-core)
+          (hsPkgs.unordered-containers)
+          (hsPkgs.vector)
+          ];
+        };
+      tests = {
+        "test" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.aeson)
+            (hsPkgs.attoparsec)
+            (hsPkgs.base64-bytestring)
+            (hsPkgs.blaze-html)
+            (hsPkgs.bytestring)
+            (hsPkgs.containers)
+            (hsPkgs.hspec)
+            (hsPkgs.http-api-data)
+            (hsPkgs.path-pieces)
+            (hsPkgs.scientific)
+            (hsPkgs.text)
+            (hsPkgs.time)
+            (hsPkgs.transformers)
+            (hsPkgs.unordered-containers)
+            (hsPkgs.vector)
+            ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/persistent";
+      rev = "c85c1b3eabd81251beb0e358257a9e97c0e3c888";
+      sha256 = "1flszbqkmm9rgrd9qgfm2689hs0i40lw34ll6djpwjvy4v9fyldl";
+      });
+    postUnpack = "sourceRoot+=/persistent; echo source root reset to \$sourceRoot";
+    }

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,9 +17,6 @@ extra-deps:
   - esqueleto-3.0.0
   - generic-monoid-0.1.0.0
   - libsystemd-journal-1.4.4
-  - persistent-2.10.0
-  - persistent-postgresql-2.10.0
-  - persistent-template-2.7.2
   - prometheus-2.1.2
   - pvss-0.2.0
   - tasty-hedgehog-1.0.0.1
@@ -75,3 +72,12 @@ extra-deps:
       - ouroboros-consensus
       - typed-protocols
       - typed-protocols-cbor
+
+  # Keep this until this is merged https://github.com/yesodweb/persistent/pull/950
+  # and a new version is released.
+  - git: https://github.com/input-output-hk/persistent
+    commit: c85c1b3eabd81251beb0e358257a9e97c0e3c888
+    subdirs:
+      - persistent
+      - persistent-postgresql
+      - persistent-template


### PR DESCRIPTION
The Persistent library had very poor (and rather broken) support
for transactions. I added better support and submitted a PR upstream,
and this PR targets a git version of Persistent in an IOHK repo.