### PR TITLE
node: Run DB migration on startup

### DIFF
--- a/cardano-explorer-node/app/cardano-explorer-node.hs
+++ b/cardano-explorer-node/app/cardano-explorer-node.hs
@@ -8,6 +8,7 @@ import           Cardano.Shell.Lib (CardanoApplication (..), ApplicationEnvironm
 import qualified Cardano.Shell.Lib as Shell
 import qualified Cardano.Shell.Presets as Shell
 
+import           Explorer.DB (MigrationDir (..))
 import           Explorer.Node (ExplorerNodeParams (..), NodeLayer (..), initializeAllFeatures)
 
 import           Options.Applicative (Parser, ParserInfo, completer, bashCompleter, help, long, strOption)
@@ -38,7 +39,16 @@ pCommandLine =
     <$> Shell.loggingParser
     <*> Node.parseCommonCLI
     <*> parseSocketPath
+    <*> pMigrationDir
 
 -- TODO, another PR is adding similar to another repo, switch over to it
 parseSocketPath :: Parser FilePath
 parseSocketPath = strOption (long "socket-path" <> help "path to a cardano-node socket" <> completer (bashCompleter "file"))
+
+pMigrationDir :: Parser MigrationDir
+pMigrationDir =
+  MigrationDir <$> Opt.strOption
+    (  Opt.long "schema-dir"
+    <> Opt.help "The directory containing the migrations."
+    <> Opt.completer (Opt.bashCompleter "directory")
+    )

--- a/cardano-explorer-node/cardano-explorer-node.cabal
+++ b/cardano-explorer-node/cardano-explorer-node.cabal
@@ -87,6 +87,7 @@ executable cardano-explorer-node
   build-depends:        base                            >= 4.12         && < 4.13
                       , bytestring
                       , cardano-crypto-wrapper
+                      , cardano-explorer-db
                       , cardano-explorer-node
                       , cardano-ledger
                       , cardano-node

--- a/cardano-explorer-node/src/Explorer/Node.hs
+++ b/cardano-explorer-node/src/Explorer/Node.hs
@@ -53,6 +53,8 @@ import           Data.Functor.Contravariant (contramap)
 import           Data.Reflection (give)
 import qualified Data.Text as Text
 
+
+import           Explorer.DB (LogFileDir (..), MigrationDir)
 import qualified Explorer.DB as DB
 import           Explorer.Node.Insert
 import           Explorer.Node.Rollback
@@ -110,6 +112,7 @@ data ExplorerNodeParams = ExplorerNodeParams
   { enpLogging :: !LoggingCLIArguments
   , enpCommon :: Node.CommonCLI
   , enpSocketPath :: FilePath
+  , enpMigrationDir :: MigrationDir
   }
 
 newtype NodeLayer = NodeLayer
@@ -121,6 +124,7 @@ type NodeCardanoFeature = CardanoFeatureInit LoggingLayer ExplorerNodeParams Nod
 
 initializeAllFeatures :: ExplorerNodeParams -> PartialCardanoConfiguration -> CardanoEnvironment -> IO ([CardanoFeature], NodeLayer)
 initializeAllFeatures enp partialConfig cardanoEnvironment = do
+  DB.runMigrations True (enpMigrationDir enp) (LogFileDir "/tmp")
   let fcc = finaliseCardanoConfiguration $ Node.mergeConfiguration partialConfig (enpCommon enp)
   finalConfig <- case fcc of
                   Left err -> throwIO $ ConfigurationError err

--- a/nix/.stack.nix/cardano-explorer-node.nix
+++ b/nix/.stack.nix/cardano-explorer-node.nix
@@ -57,6 +57,7 @@
             (hsPkgs.base)
             (hsPkgs.bytestring)
             (hsPkgs.cardano-crypto-wrapper)
+            (hsPkgs.cardano-explorer-db)
             (hsPkgs.cardano-explorer-node)
             (hsPkgs.cardano-ledger)
             (hsPkgs.cardano-node)


### PR DESCRIPTION
Requires an extra command line parameter `--schema-dir`. If the migration fails it will hard fail with an error message pointing to a log file.