### PR TITLE
make nix scripts work correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ dist-newstyle/
 .stack-work/
 dist
 *.swp
+log-dir
+result*
+launch_*

--- a/default.nix
+++ b/default.nix
@@ -32,23 +32,6 @@ let
     inherit (iohkLib.nix-tools) iohk-extras iohk-module;
   };
 
-  mkConnectScript = { genesisFile, genesisHash, name, ... }:
-  let
-    extraModule = {
-      services.cardano-exporter = {
-        enable = true;
-        inherit genesisFile genesisHash;
-        cluster = name;
-      };
-    };
-    eval = pkgs.lib.evalModules {
-      prefix = [];
-      check = false;
-      modules = [ ./module.nix extraModule customConfig ];
-      args = { inherit pkgs; };
-    };
-  in eval.config.services.cardano-exporter.script;
-
 in {
   inherit pkgs iohkLib src haskellPackages;
   inherit (haskellPackages.cardano-explorer.identifier) version;
@@ -62,7 +45,9 @@ in {
   tests = util.collectComponents "tests" util.isIohkSkeleton haskellPackages;
   benchmarks = util.collectComponents "benchmarks" util.isIohkSkeleton haskellPackages;
 
-  scripts.exporter = iohkLib.cardanoLib.forEnvironments mkConnectScript;
+  scripts = pkgs.callPackage ./nix/scripts.nix {
+    inherit iohkLib customConfig;
+  };
 
   # This provides a development environment that can be used with nix-shell or
   # lorri. See https://input-output-hk.github.io/haskell.nix/user-guide/development/

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -1,0 +1,28 @@
+{ iohkLib, customConfig }:
+with iohkLib.pkgs.lib;
+let
+  pkgs = iohkLib.pkgs;
+  mkConnectScript = envConfig: let
+    extraModule = {
+      services.cardano-exporter = {
+        enable = true;
+        inherit (envConfig) genesisHash;
+        cluster = envConfig.name;
+      };
+    };
+    systemdCompat.options = {
+      systemd.services = mkOption {};
+      services.postgresql = mkOption {};
+      users = mkOption {};
+    };
+    eval = pkgs.lib.evalModules {
+      prefix = [];
+      modules = [ ./nixos/cardano-exporter-service.nix systemdCompat extraModule customConfig ];
+      args = { inherit pkgs; };
+    };
+  in eval.config.services.cardano-exporter.script;
+
+  scripts = iohkLib.cardanoLib.forEnvironments (environment: {
+    exporter = mkConnectScript environment;
+  });
+in scripts


### PR DESCRIPTION
This moves the scripts to nix/scripts.nix. It makes it properly fail if options are set incorrectly. It makes it have the right params in the script itself and it adds the ability to override cardano-node socket path with ENV var.