### PR TITLE
WIP: Implement POM design in `cardano-explorer-node`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -131,13 +131,13 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: d92e1d426af872346ff73a173446796de810353f
+  tag: 38b6133f5678bbc32712f207b049d49e1cc274d2
   subdir: cardano-node
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: d92e1d426af872346ff73a173446796de810353f
+  tag: 38b6133f5678bbc32712f207b049d49e1cc274d2
   subdir: cardano-config
 
 source-repository-package

--- a/cardano-explorer-db/src/Explorer/DB/Migration.hs
+++ b/cardano-explorer-db/src/Explorer/DB/Migration.hs
@@ -43,7 +43,7 @@ import           System.IO (Handle, IOMode (AppendMode), hClose, hFlush, hPrint,
 
 
 newtype MigrationDir
-  = MigrationDir FilePath
+  = MigrationDir { migDir :: FilePath }
 
 newtype LogFileDir
   = LogFileDir FilePath

--- a/nix/.stack.nix/cardano-config.nix
+++ b/nix/.stack.nix/cardano-config.nix
@@ -50,8 +50,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "d92e1d426af872346ff73a173446796de810353f";
-      sha256 = "1pp3hv4wzqb5arpxf5brfhra3mq4vgyipygy1c324bngw61id6xv";
+      rev = "38b6133f5678bbc32712f207b049d49e1cc274d2";
+      sha256 = "0bhyj71qyk68ynxiqgnr4wg518q9zdjf5cs478ggfy146im1cqjy";
       });
     postUnpack = "sourceRoot+=/cardano-config; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -205,8 +205,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "d92e1d426af872346ff73a173446796de810353f";
-      sha256 = "1pp3hv4wzqb5arpxf5brfhra3mq4vgyipygy1c324bngw61id6xv";
+      rev = "38b6133f5678bbc32712f207b049d49e1cc274d2";
+      sha256 = "0bhyj71qyk68ynxiqgnr4wg518q9zdjf5cs478ggfy146im1cqjy";
       });
     postUnpack = "sourceRoot+=/cardano-node; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -61,7 +61,7 @@ extra-deps:
       - plugins/scribe-systemd
 
   - git: https://github.com/input-output-hk/cardano-node
-    commit: d92e1d426af872346ff73a173446796de810353f
+    commit: 38b6133f5678bbc32712f207b049d49e1cc274d2
     subdirs:
       - cardano-config
       - cardano-node


### PR DESCRIPTION
This [PR](https://github.com/input-output-hk/cardano-node/pull/271) needs to be merged first and then the `stack.yaml` & `cabal.project` files need to be updated here again. This should fix the log config file issue below.
Before:
```
PGPASSFILE=config/pgpass mainnet-node-local/bin/cardano-explorer-node \
    --log-config ../cardano-node/configuration/log-configuration.yaml \
    --genesis-file ../cardano-node/mainnet-genesis.json \
    --genesis-hash 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb \
    --socket-path ../cardano-node/state-node-mainnet/socket/node-core-0.socket \
    --schema-dir schema/
Cannot find the logging configuration file at location.
cardano-explorer-node: File not found on path './configuration/log-configuration.yaml'.
```
After:
```
 PGPASSFILE=config/pgpass mainnet-node-local/bin/cardano-explorer-node \                                                                                       
    --log-config ../cardano-node/configuration/log-configuration.yaml \
    --genesis-file ../cardano-node/mainnet-genesis.json \
    --genesis-hash 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb \
    --socket-dir ../cardano-node/state-node-mainnet/socket/node-core-0.socket \
    --schema-dir schema/
[iohk.cardano.#messagecounters.aggregation:Debug:10] [2019-10-30 17:18:25.68 UTC] time_interval_(s) = 0
[iohk.cardano.#messagecounters.monitoring:Debug:13] [2019-10-30 17:18:25.68 UTC] time_interval_(s) = 0
[iohk.cardano.explorer-db-node:Info:1] [2019-10-30 17:18:25.68 UTC] Initial genesis distribution present and correct
[iohk.cardano.explorer-db-node:Info:1] [2019-10-30 17:18:25.68 UTC] Total genesis supply of Ada: 31112484745.000000
[iohk.cardano.explorer-db-node:Info:1] [2019-10-30 17:18:25.68 UTC] Starting node client
...
```
NB: `--socket-path` is now `--socket-dir`