### PR TITLE
make hydra only wait for the docker inputs, but not the docker compression

### DIFF
--- a/docker/default.nix
+++ b/docker/default.nix
@@ -418,33 +418,35 @@ let
       [ patchedRunit stop eval.config.services.postgresql.package deroot ];
   };
 
+  contents = [
+    patchedRunit
+    configFiles
+    coreutils
+    bashInteractive
+    sudo
+    linux-pam
+    nettools
+    lsof
+    iana_etc
+    stop
+    strace
+    procps
+    cacert.out
+    eval.config.services.postgresql.package
+    gnugrep
+    less
+    curl
+    utillinux
+    deroot
+    passwd
+  ];
+
   image = dockerTools.buildLayeredImage {
     name = "docker-image";
     tag = environment;
     maxLayers = 100;
-    contents = [
-      patchedRunit
-      configFiles
-      coreutils
-      bashInteractive
-      sudo
-      linux-pam
-      nettools
-      lsof
-      iana_etc
-      stop
-      strace
-      procps
-      cacert.out
-      eval.config.services.postgresql.package
-      gnugrep
-      less
-      curl
-      utillinux
-      deroot
-      passwd
-    ];
     config = { Cmd = [ startRunit ]; };
+    inherit contents;
   };
 
   helper = writeScript "helper" ''
@@ -453,8 +455,12 @@ let
     docker load < ${image}
     docker run --rm -t -i -p 80:80 --tty --cap-add SYS_PTRACE --name test-image --volume explorer-${environment}:/var/ docker-image:${environment}
   '';
+  hydraJob = runCommand "hydra-docker-check" { inherit contents startRunit; preferLocalBuild = true; } ''
+    touch $out
+    echo all docker inputs built successfully
+  '';
 in {
-  inherit image helper configFiles;
+  inherit image helper configFiles hydraJob;
   inherit users userToPasswd lib passwd userToUseradd dockerFileSetup
     dockerFileBinaries;
 

--- a/release.nix
+++ b/release.nix
@@ -43,14 +43,14 @@ let
 
   inherit (systems.examples) mingwW64 musl64;
   inherit (import ./nix/nixos/tests { }) chairmansCluster;
-  inherit (import ./docker { }) dockerImageJob;
+  inherit (import ./docker { }) hydraJob;
 
   jobs = {
     native = mapTestOn (packagePlatforms project);
     #"${mingwW64.config}" = mapTestOnCross mingwW64 (packagePlatformsCross project);
 
     chairmansCluster = chairmansCluster.x86_64-linux;
-    inherit dockerImageJob;
+    docker-inputs = hydraJob;
   }
   // (
   # This aggregate job is what IOHK Hydra uses to update
@@ -65,7 +65,7 @@ let
       jobs.native.cardano-explorer-node.x86_64-linux
       jobs.native.cardano-sl-core.x86_64-linux
       jobs.chairmansCluster
-      jobs.dockerImageJob
+      jobs.docker-inputs
     ]
   ))
 


### PR DESCRIPTION
the only thing that can fail after that point is gzip and tar