### PR TITLE
webapi: Improve the AddressSummary endpoint

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -4,6 +4,8 @@ packages:
   cardano-explorer-node
   cardano-explorer
 
+constraints:
+  brick >= 0.47 && < 0.50
 
 package cardano-explorer-db
   ghc-options: -Wall -Werror -fwarn-redundant-constraints

--- a/cardano-explorer/cardano-explorer.cabal
+++ b/cardano-explorer/cardano-explorer.cabal
@@ -69,6 +69,7 @@ library
                       , cardano-crypto-class
                       , cardano-explorer-db
                       , cardano-ledger
+                      , containers
                       , deepseq
                       , esqueleto
                       , extra

--- a/cardano-explorer/src/Explorer/Web/Server/AddressSummary.hs
+++ b/cardano-explorer/src/Explorer/Web/Server/AddressSummary.hs
@@ -13,6 +13,9 @@ import           Control.Monad.Trans.Reader (ReaderT)
 
 import           Data.ByteString.Char8 (ByteString)
 import qualified Data.List as List
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.List.Extra (groupOn)
 import           Data.Maybe
 import           Data.Text (Text)
 import           Data.Time.Clock (UTCTime)
@@ -20,11 +23,10 @@ import           Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import           Data.Word (Word64)
 
 import           Database.Esqueleto (InnerJoin (..), Value (..),
-                    (^.), (==.), (&&.), distinct, from, on, select, val, where_)
+                    (^.), (==.), (&&.), distinct, from, in_, on, select, val, valList, where_)
 import           Database.Persist.Sql (SqlBackend)
 
 import           Explorer.DB (EntityField (..), TxId, unValue3)
-
 import           Explorer.Web.ClientTypes (CAddress (..), CAddressSummary (..), CAddressType (..),
                     CCoin (..), CHash (..), CTxBrief (..), CTxHash (..), mkCCoin, sumCCoin)
 import           Explorer.Web.Error (ExplorerError (..))
@@ -41,11 +43,12 @@ import           Servant (Handler)
 
 -- Example regular addresses:
 --    /api/addresses/summary/DdzFFzCqrhsszHTvbjTmYje5hehGbadkT6WgWbaqCy5XNxNttsPNF13eAjjBHYT7JaLJz2XVxiucam1EvwBRPSTiCrT4TNCBas4hfzic
---    /api/addresses/summary/DdzFFzCqrht1XitMM2mA1Qp4iW2jcX1Gx6f7tcJ4mfzXdS5VUW9sM28UejDGxz6eUDvdMTeuTqwZdSUwDiezcTafs89DNKEsSoCAX9ji
 --    /api/addresses/summary/DdzFFzCqrhsq7KBnN2VngWtvPMriYFCNwWxW5PSnooLeNhNaz6Q2GhyfjHn7sY3BNiymhAkcCSTRhTBe8PZXSEEewuyWryURhmozdd6b
---    /api/addresses/summary/DdzFFzCqrhtCMkF4akdRbon1FFXStuc3YjW1gvYdE8sQKVUsgtUAwF5wf8EtSdCQ4biCRueMSDQSouqrSdhWbz2u41Xzt6WKEShgBynd
 --    /api/addresses/summary/DdzFFzCqrht7YAnA3PW3RQEdYdQMQdodHG87H6vF766xVZuXjc3hkBN9PH8oQZGxAdQhiqgTYm24KAZyEGh3N6yxjj6Y5LfWJE83ngLp
 --    /api/addresses/summary/DdzFFzCqrhsqz23SkTxevzJ3Dn4ee14BpQVe5T9LX2yWJpcjHToP2qxnzaEiy5qiHwNVtX5ANXtLJyBwKz8PvjJZYq2n8fyy7Dp9RqXa
+
+--    /api/addresses/summary/DdzFFzCqrht1XitMM2mA1Qp4iW2jcX1Gx6f7tcJ4mfzXdS5VUW9sM28UejDGxz6eUDvdMTeuTqwZdSUwDiezcTafs89DNKEsSoCAX9ji
+--    /api/addresses/summary/DdzFFzCqrhtCMkF4akdRbon1FFXStuc3YjW1gvYdE8sQKVUsgtUAwF5wf8EtSdCQ4biCRueMSDQSouqrSdhWbz2u41Xzt6WKEShgBynd
 
 -- Binance cold storage address (huge number of inputs and outputs):
 --    /api/addresses/summary/DdzFFzCqrhtBatWqyFge4w6M6VLgNUwRHiXTAg3xfQCUdTcjJxSrPHVZJBsQprUEc5pRhgMWQaGciTssoZVwrSKmG1fneZ1AeCtLgs5Y
@@ -82,15 +85,15 @@ queryAddressSummary addr = do
                 pure (tx ^. TxId, tx ^. TxHash, blk ^. BlockTime)
 
     cAddressSummary
-        <$> mapM (queryCTxBrief . unValue3) inrows
-        <*> mapM (queryCTxBrief . unValue3) outrows
+        <$> queryCTxBriefs (map unValue3 inrows)
+        <*> queryCTxBriefs (map unValue3 outrows)
   where
     cAddressSummary :: [CTxBrief] -> [CTxBrief] -> CAddressSummary
     cAddressSummary itxs otxs =
       let insum = sumCCoin . map snd $ filter isTargetAddress (concatMap ctbOutputs itxs)
           outsum = sumCCoin . map snd . filter isTargetAddress $ catMaybes (concatMap ctbInputs otxs)
           txs = List.sortOn ctbTimeIssued (itxs ++ otxs)
-          fees = sumCCoin $ map ctbFees (itxs ++ otxs)
+          fees = sumCCoin $ map ctbFees txs
       in
       CAddressSummary
         { caAddress = CAddress addr
@@ -108,33 +111,75 @@ queryAddressSummary addr = do
 
 -- -------------------------------------------------------------------------------------------------
 
--- This is similar but different from the query of the same name in Explorer.Web.Server.BlocksTxs.
-queryCTxBrief :: MonadIO m => (TxId, ByteString, UTCTime) -> ReaderT SqlBackend m CTxBrief
-queryCTxBrief (txid, txhash, utctime) = do
-    inrows <- select . from $ \(tx `InnerJoin` txIn `InnerJoin` txOut) -> do
+queryCTxBriefs :: MonadIO m => [(TxId, ByteString, UTCTime)] -> ReaderT SqlBackend m [CTxBrief]
+queryCTxBriefs [] = pure []
+queryCTxBriefs xs = do
+  let txids = map fst3 xs
+  zipTxBrief xs <$> queryTxInputs txids <*> queryTxOutputs txids
+
+queryTxInputs :: MonadIO m => [TxId] -> ReaderT SqlBackend m [(TxId, [(CAddress, Word64)])]
+queryTxInputs txids = do
+    rows <- select . distinct . from $ \(tx `InnerJoin` txIn `InnerJoin` txOut) -> do
                 on (txIn ^. TxInTxOutId ==. txOut ^. TxOutTxId
                     &&. txIn ^. TxInTxOutIndex ==. txOut ^. TxOutIndex)
-                on (tx ^. TxId ==. val txid)
-                where_ (txIn ^. TxInTxInId ==. val txid)
-                pure (txOut ^. TxOutAddress, txOut ^. TxOutValue)
-    let inputs = map convert inrows
-
-    outrows <- select . from $ \ (tx `InnerJoin` txOut) -> do
-                  on (tx ^. TxId ==. txOut ^. TxOutTxId)
-                  where_ (tx ^. TxId ==. val txid)
-                  pure (txOut ^. TxOutAddress, txOut ^. TxOutValue)
-    let outputs = map convert outrows
-        inSum = sum $ map snd inputs
-        outSum = sum $ map snd outputs
-    pure $ CTxBrief
-            { ctbId = CTxHash . CHash $ bsBase16Encode txhash
-            , ctbTimeIssued = Just $ utcTimeToPOSIXSeconds utctime
-            , ctbInputs = map (Just . fmap (mkCCoin . fromIntegral)) inputs
-            , ctbOutputs = map (fmap (mkCCoin . fromIntegral)) outputs
-            , ctbInputSum = mkCCoin $ fromIntegral inSum
-            , ctbOutputSum = mkCCoin $ fromIntegral outSum
-            , ctbFees = mkCCoin $ fromIntegral (inSum - outSum)
-            }
+                on (tx ^. TxId ==. txIn ^. TxInTxInId)
+                where_ (txIn ^. TxInTxInId `in_` valList txids)
+                pure (tx ^. TxId, txOut ^. TxOutAddress, txOut ^. TxOutValue)
+    case groupOn fst (map convert rows) of
+      [] -> pure []
+      xs -> pure $ map collapseTxGroup xs
   where
-    convert :: (Value Text, Value Word64) -> (CAddress, Word64)
-    convert (Value addr, Value coin) = (CAddress addr, coin)
+    convert :: (Value TxId, Value Text, Value Word64) -> (TxId, (CAddress, Word64))
+    convert (Value txid, Value addr, Value coin) = (txid, (CAddress addr, coin))
+
+queryTxOutputs :: MonadIO m => [TxId] -> ReaderT SqlBackend m [(TxId, [(CAddress, Word64)])]
+queryTxOutputs txids = do
+    rows <- select . from $ \ (tx `InnerJoin` txOut) -> do
+                on (tx ^. TxId ==. txOut ^. TxOutTxId)
+                where_ (tx ^. TxId `in_` valList txids)
+                pure (tx ^. TxId, txOut ^. TxOutAddress, txOut ^. TxOutValue)
+    case groupOn fst (map convert rows) of
+      [] -> pure []
+      xs -> pure $ map collapseTxGroup xs
+  where
+    convert :: (Value TxId, Value Text, Value Word64) -> (TxId, (CAddress, Word64))
+    convert (Value txid, Value addr, Value coin) = (txid, (CAddress addr, coin))
+
+-- -------------------------------------------------------------------------------------------------
+
+collapseTxGroup :: [(TxId, (CAddress, Word64))] -> (TxId, [(CAddress, Word64)])
+collapseTxGroup xs =
+  case xs of
+    [] -> error "collapseTxGroup: groupOn produced [] on non-empty list (impossible)"
+    (x:_) -> (fst x, map snd xs)
+
+zipTxBrief :: [(TxId, ByteString, UTCTime)] -> [(TxId, [(CAddress, Word64)])] -> [(TxId, [(CAddress, Word64)])] -> [CTxBrief]
+zipTxBrief xs ins outs =
+    mapMaybe build $ map fst3 xs
+  where
+    idMap :: Map TxId (ByteString, UTCTime)
+    idMap = Map.fromList $ map (\(a, b, c) -> (a, (b, c))) xs
+
+    inMap, outMap :: Map TxId [(CAddress, Word64)]
+    inMap = Map.fromList ins
+    outMap = Map.fromList outs
+
+    build :: TxId -> Maybe CTxBrief
+    build txid = do
+      (hash, time) <- Map.lookup txid idMap
+      inputs <- Map.lookup txid inMap
+      outputs <- Map.lookup txid outMap
+      inSum <- Just $ sum (map snd inputs)
+      outSum <- Just $ sum (map snd outputs)
+      pure $ CTxBrief
+              { ctbId = CTxHash . CHash $ bsBase16Encode hash
+              , ctbTimeIssued = Just $ utcTimeToPOSIXSeconds time
+              , ctbInputs = map (Just . fmap (mkCCoin . fromIntegral)) inputs
+              , ctbOutputs = map (fmap (mkCCoin . fromIntegral)) outputs
+              , ctbInputSum = mkCCoin $ fromIntegral inSum
+              , ctbOutputSum = mkCCoin $ fromIntegral outSum
+              , ctbFees = mkCCoin $ fromIntegral (inSum - outSum)
+              }
+
+fst3 :: (a, b, c) -> a
+fst3 (a, _, _) = a

--- a/nix/.stack.nix/cardano-explorer.nix
+++ b/nix/.stack.nix/cardano-explorer.nix
@@ -65,6 +65,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."cardano-crypto-class" or (buildDepError "cardano-crypto-class"))
           (hsPkgs."cardano-explorer-db" or (buildDepError "cardano-explorer-db"))
           (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
+          (hsPkgs."containers" or (buildDepError "containers"))
           (hsPkgs."deepseq" or (buildDepError "deepseq"))
           (hsPkgs."esqueleto" or (buildDepError "esqueleto"))
           (hsPkgs."extra" or (buildDepError "extra"))


### PR DESCRIPTION
The old version was doing a DB query for every transaction associated with the specified address. The new version uses a constant number of queries (6) for an address.
    
For one address (with 37000+ transactions) this drops the end-to-end query time from 40+ minutes to under 3 minutes. The old explorer satisfies this request in a little over a minute. The difference here is that the new explorer is run locally and the times are being compared to the old explorer which is being accessed at  http://cardanoexplorer.com/ .
