### PR TITLE
db: Update utxo-set command to include UTCTime of the slot

### DIFF
--- a/cardano-explorer-db/cardano-explorer-db.cabal
+++ b/cardano-explorer-db/cardano-explorer-db.cabal
@@ -98,6 +98,7 @@ executable cardano-explorer-db-tool
                       , persistent
                       , random
                       , text
+                      , time
 
 test-suite test
   default-language:     Haskell2010

--- a/nix/.stack.nix/cardano-explorer-db.nix
+++ b/nix/.stack.nix/cardano-explorer-db.nix
@@ -98,6 +98,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."persistent" or (buildDepError "persistent"))
             (hsPkgs."random" or (buildDepError "random"))
             (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
             ];
           buildable = true;
           };


### PR DESCRIPTION
If the specified slot number is in the future, just the date at which the slot will occur will be printed. If the specified slot number has already occurred it will extract the Utxo set as before.
