### PR TITLE
Sync dependencies with cardano-node

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -65,7 +65,7 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-shell
   subdir: cardano-shell
-  tag: 4d26bcefc0edcd99154c85170ef028775c6dd1e0
+  tag: f700afeb24163332dc00306508ca410b7873521d
 
 source-repository-package
   type: git
@@ -133,13 +133,13 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 3fa095c7caf2e47dcf0ab3e0612d4a457c54515d
+  tag: d402dd42874ae0acbbfb4c42ffb2a773370f1f3d
   subdir: cardano-node
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 3fa095c7caf2e47dcf0ab3e0612d4a457c54515d
+  tag: d402dd42874ae0acbbfb4c42ffb2a773370f1f3d
   subdir: cardano-config
 
 source-repository-package
@@ -163,7 +163,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: dbdb643722e431e4d232345a0eafdc7bdeab7b60
+  tag: 52ffa26e6d5a204345ddc3e375b17cf1c96d3412
   subdir: cardano-ledger
 
 source-repository-package
@@ -174,71 +174,71 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 11b674a10e76ab266a37225d82955fd8b1f80e27
+  tag: c1f9d85f50a6e71b2376618cb57656a1b7192ef1
   subdir: byron/semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 11b674a10e76ab266a37225d82955fd8b1f80e27
+  tag: c1f9d85f50a6e71b2376618cb57656a1b7192ef1
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 11b674a10e76ab266a37225d82955fd8b1f80e27
+  tag: c1f9d85f50a6e71b2376618cb57656a1b7192ef1
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: dbdb643722e431e4d232345a0eafdc7bdeab7b60
+  tag: 52ffa26e6d5a204345ddc3e375b17cf1c96d3412
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: dbdb643722e431e4d232345a0eafdc7bdeab7b60
+  tag: 52ffa26e6d5a204345ddc3e375b17cf1c96d3412
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: dbdb643722e431e4d232345a0eafdc7bdeab7b60
+  tag: 52ffa26e6d5a204345ddc3e375b17cf1c96d3412
   subdir: crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc164b5a3cbcd239a5803b5d3925205d29837a7c
+  tag: babf1a855e6bc745321b2516837f5cac174b6943
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc164b5a3cbcd239a5803b5d3925205d29837a7c
+  tag: babf1a855e6bc745321b2516837f5cac174b6943
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc164b5a3cbcd239a5803b5d3925205d29837a7c
+  tag: babf1a855e6bc745321b2516837f5cac174b6943
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc164b5a3cbcd239a5803b5d3925205d29837a7c
+  tag: babf1a855e6bc745321b2516837f5cac174b6943
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc164b5a3cbcd239a5803b5d3925205d29837a7c
+  tag: babf1a855e6bc745321b2516837f5cac174b6943
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc164b5a3cbcd239a5803b5d3925205d29837a7c
+  tag: babf1a855e6bc745321b2516837f5cac174b6943
   subdir: typed-protocols-cbor

--- a/nix/.stack.nix/cardano-config.nix
+++ b/nix/.stack.nix/cardano-config.nix
@@ -93,8 +93,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "3fa095c7caf2e47dcf0ab3e0612d4a457c54515d";
-      sha256 = "01q0mn7bhk04dsxsxiwg8zx5llv6fqw3sjr5mgpyqarinwpxb5ss";
+      rev = "d402dd42874ae0acbbfb4c42ffb2a773370f1f3d";
+      sha256 = "1ksl6yqm8s485bxdahxmzcs0k6f7dy7s461hqgc6bclcdkjs1vsl";
       });
     postUnpack = "sourceRoot+=/cardano-config; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -75,8 +75,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "dbdb643722e431e4d232345a0eafdc7bdeab7b60";
-      sha256 = "0vql7f53dq8zf595l3kzdzssz5801pz6z140q5fpnk38kr97s9da";
+      rev = "52ffa26e6d5a204345ddc3e375b17cf1c96d3412";
+      sha256 = "0q2g60idkpinf6mb0krglxmd2cai33qamdsfgh2ywywin8bvrs24";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -102,8 +102,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "dbdb643722e431e4d232345a0eafdc7bdeab7b60";
-      sha256 = "0vql7f53dq8zf595l3kzdzssz5801pz6z140q5fpnk38kr97s9da";
+      rev = "52ffa26e6d5a204345ddc3e375b17cf1c96d3412";
+      sha256 = "0q2g60idkpinf6mb0krglxmd2cai33qamdsfgh2ywywin8bvrs24";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -96,8 +96,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "dbdb643722e431e4d232345a0eafdc7bdeab7b60";
-      sha256 = "0vql7f53dq8zf595l3kzdzssz5801pz6z140q5fpnk38kr97s9da";
+      rev = "52ffa26e6d5a204345ddc3e375b17cf1c96d3412";
+      sha256 = "0q2g60idkpinf6mb0krglxmd2cai33qamdsfgh2ywywin8bvrs24";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -160,8 +160,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "dbdb643722e431e4d232345a0eafdc7bdeab7b60";
-      sha256 = "0vql7f53dq8zf595l3kzdzssz5801pz6z140q5fpnk38kr97s9da";
+      rev = "52ffa26e6d5a204345ddc3e375b17cf1c96d3412";
+      sha256 = "0q2g60idkpinf6mb0krglxmd2cai33qamdsfgh2ywywin8bvrs24";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -262,8 +262,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "3fa095c7caf2e47dcf0ab3e0612d4a457c54515d";
-      sha256 = "01q0mn7bhk04dsxsxiwg8zx5llv6fqw3sjr5mgpyqarinwpxb5ss";
+      rev = "d402dd42874ae0acbbfb4c42ffb2a773370f1f3d";
+      sha256 = "1ksl6yqm8s485bxdahxmzcs0k6f7dy7s461hqgc6bclcdkjs1vsl";
       });
     postUnpack = "sourceRoot+=/cardano-node; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-shell.nix
+++ b/nix/.stack.nix/cardano-shell.nix
@@ -104,8 +104,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-shell";
-      rev = "4d26bcefc0edcd99154c85170ef028775c6dd1e0";
-      sha256 = "1vl1sf8labbak51ms6bxnfvda476v99lbjmzmkr9xr9zv5974pnr";
+      rev = "f700afeb24163332dc00306508ca410b7873521d";
+      sha256 = "07qfhqygzngscvk6dxc9jd6aasid8cmnqw5xs612lspvz9pj80m2";
       });
     postUnpack = "sourceRoot+=/cardano-shell; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-blockchain.nix
+++ b/nix/.stack.nix/cs-blockchain.nix
@@ -47,7 +47,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       copyright = "";
       maintainer = "formal.methods@iohk.io";
       author = "IOHK Formal Methods Team";
-      homepage = "https://github.com/input-output-hk/cardano-chain";
+      homepage = "https://github.com/input-output-hk/cardano-legder-specs";
       url = "";
       synopsis = "Executable specification of the Cardano blockchain";
       description = "";
@@ -92,8 +92,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "11b674a10e76ab266a37225d82955fd8b1f80e27";
-      sha256 = "1x33w8psg4bpai4cx56y8h50mxblri8j58vj3vic57wfrh7634cb";
+      rev = "c1f9d85f50a6e71b2376618cb57656a1b7192ef1";
+      sha256 = "0waghgbr5f3x3fm2x1yx0ayrkmx1n0rah0mpgkjbbla9bhqpf5fg";
       });
     postUnpack = "sourceRoot+=/byron/chain/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -47,7 +47,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       copyright = "";
       maintainer = "formal.methods@iohk.io";
       author = "IOHK Formal Methods Team";
-      homepage = "https://github.com/input-output-hk/cardano-chain";
+      homepage = "https://github.com/input-output-hk/cardano-legder-specs";
       url = "";
       synopsis = "Executable specification of Cardano ledger";
       description = "";
@@ -112,8 +112,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "11b674a10e76ab266a37225d82955fd8b1f80e27";
-      sha256 = "1x33w8psg4bpai4cx56y8h50mxblri8j58vj3vic57wfrh7634cb";
+      rev = "c1f9d85f50a6e71b2376618cb57656a1b7192ef1";
+      sha256 = "0waghgbr5f3x3fm2x1yx0ayrkmx1n0rah0mpgkjbbla9bhqpf5fg";
       });
     postUnpack = "sourceRoot+=/byron/ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -70,8 +70,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "fc164b5a3cbcd239a5803b5d3925205d29837a7c";
-      sha256 = "0pddd2dh5sk8b26ad3jgn7b38s0f629nmjhsqn2mrf1zdkmk7xqh";
+      rev = "babf1a855e6bc745321b2516837f5cac174b6943";
+      sha256 = "1vsrb3c9y9s5b3i1pqmv2m2ifs6wlcksn8nxpcfxvcgcmnvscz01";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -104,8 +104,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "fc164b5a3cbcd239a5803b5d3925205d29837a7c";
-      sha256 = "0pddd2dh5sk8b26ad3jgn7b38s0f629nmjhsqn2mrf1zdkmk7xqh";
+      rev = "babf1a855e6bc745321b2516837f5cac174b6943";
+      sha256 = "1vsrb3c9y9s5b3i1pqmv2m2ifs6wlcksn8nxpcfxvcgcmnvscz01";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -66,6 +66,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
           (hsPkgs."bifunctors" or (buildDepError "bifunctors"))
           (hsPkgs."bimap" or (buildDepError "bimap"))
+          (hsPkgs."binary" or (buildDepError "binary"))
           (hsPkgs."bytestring" or (buildDepError "bytestring"))
           (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
           (hsPkgs."cardano-crypto-class" or (buildDepError "cardano-crypto-class"))
@@ -76,14 +77,15 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."containers" or (buildDepError "containers"))
           (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
           (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."digest" or (buildDepError "digest"))
           (hsPkgs."directory" or (buildDepError "directory"))
           (hsPkgs."filepath" or (buildDepError "filepath"))
           (hsPkgs."fingertree" or (buildDepError "fingertree"))
           (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."memory" or (buildDepError "memory"))
           (hsPkgs."mmorph" or (buildDepError "mmorph"))
           (hsPkgs."mtl" or (buildDepError "mtl"))
           (hsPkgs."network" or (buildDepError "network"))
-          (hsPkgs."pipes" or (buildDepError "pipes"))
           (hsPkgs."serialise" or (buildDepError "serialise"))
           (hsPkgs."stm" or (buildDepError "stm"))
           (hsPkgs."text" or (buildDepError "text"))
@@ -141,6 +143,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
             (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+            (hsPkgs."binary" or (buildDepError "binary"))
             (hsPkgs."bytestring" or (buildDepError "bytestring"))
             (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
             (hsPkgs."cardano-crypto-class" or (buildDepError "cardano-crypto-class"))
@@ -226,8 +229,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "fc164b5a3cbcd239a5803b5d3925205d29837a7c";
-      sha256 = "0pddd2dh5sk8b26ad3jgn7b38s0f629nmjhsqn2mrf1zdkmk7xqh";
+      rev = "babf1a855e6bc745321b2516837f5cac174b6943";
+      sha256 = "1vsrb3c9y9s5b3i1pqmv2m2ifs6wlcksn8nxpcfxvcgcmnvscz01";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -177,8 +177,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "fc164b5a3cbcd239a5803b5d3925205d29837a7c";
-      sha256 = "0pddd2dh5sk8b26ad3jgn7b38s0f629nmjhsqn2mrf1zdkmk7xqh";
+      rev = "babf1a855e6bc745321b2516837f5cac174b6943";
+      sha256 = "1vsrb3c9y9s5b3i1pqmv2m2ifs6wlcksn8nxpcfxvcgcmnvscz01";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -47,7 +47,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       copyright = "";
       maintainer = "formal.methods@iohk.io";
       author = "IOHK Formal Methods Team";
-      homepage = "https://github.com/input-output-hk/cardano-chain";
+      homepage = "https://github.com/input-output-hk/cardano-legder-specs";
       url = "";
       synopsis = "Small step semantics";
       description = "";
@@ -58,6 +58,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
           (hsPkgs."containers" or (buildDepError "containers"))
           (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
           (hsPkgs."free" or (buildDepError "free"))
@@ -67,6 +68,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."lens" or (buildDepError "lens"))
           (hsPkgs."mtl" or (buildDepError "mtl"))
           (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
           (hsPkgs."cardano-crypto-class" or (buildDepError "cardano-crypto-class"))
           ];
         buildable = true;
@@ -100,6 +102,11 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."tasty" or (buildDepError "tasty"))
             (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
             (hsPkgs."tasty-expected-failure" or (buildDepError "tasty-expected-failure"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."Unique" or (buildDepError "Unique"))
+            (hsPkgs."cardano-crypto-class" or (buildDepError "cardano-crypto-class"))
+            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
             (hsPkgs."small-steps" or (buildDepError "small-steps"))
             ];
           buildable = true;
@@ -109,8 +116,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "11b674a10e76ab266a37225d82955fd8b1f80e27";
-      sha256 = "1x33w8psg4bpai4cx56y8h50mxblri8j58vj3vic57wfrh7634cb";
+      rev = "c1f9d85f50a6e71b2376618cb57656a1b7192ef1";
+      sha256 = "0waghgbr5f3x3fm2x1yx0ayrkmx1n0rah0mpgkjbbla9bhqpf5fg";
       });
     postUnpack = "sourceRoot+=/byron/semantics/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -86,8 +86,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "fc164b5a3cbcd239a5803b5d3925205d29837a7c";
-      sha256 = "0pddd2dh5sk8b26ad3jgn7b38s0f629nmjhsqn2mrf1zdkmk7xqh";
+      rev = "babf1a855e6bc745321b2516837f5cac174b6943";
+      sha256 = "1vsrb3c9y9s5b3i1pqmv2m2ifs6wlcksn8nxpcfxvcgcmnvscz01";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -85,8 +85,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "fc164b5a3cbcd239a5803b5d3925205d29837a7c";
-      sha256 = "0pddd2dh5sk8b26ad3jgn7b38s0f629nmjhsqn2mrf1zdkmk7xqh";
+      rev = "babf1a855e6bc745321b2516837f5cac174b6943";
+      sha256 = "1vsrb3c9y9s5b3i1pqmv2m2ifs6wlcksn8nxpcfxvcgcmnvscz01";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,7 @@ extra-deps:
   - Unique-0.4.7.6
 
   - git: https://github.com/input-output-hk/cardano-shell
-    commit: 4d26bcefc0edcd99154c85170ef028775c6dd1e0
+    commit: f700afeb24163332dc00306508ca410b7873521d
     subdirs:
       - cardano-shell
 
@@ -66,7 +66,7 @@ extra-deps:
       - plugins/scribe-systemd
 
   - git: https://github.com/input-output-hk/cardano-node
-    commit: 3fa095c7caf2e47dcf0ab3e0612d4a457c54515d
+    commit: d402dd42874ae0acbbfb4c42ffb2a773370f1f3d
     subdirs:
       - cardano-config
       - cardano-node
@@ -82,14 +82,14 @@ extra-deps:
     commit: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 11b674a10e76ab266a37225d82955fd8b1f80e27
+    commit: c1f9d85f50a6e71b2376618cb57656a1b7192ef1
     subdirs:
       - byron/semantics/executable-spec
       - byron/ledger/executable-spec
       - byron/chain/executable-spec
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: dbdb643722e431e4d232345a0eafdc7bdeab7b60
+    commit: 52ffa26e6d5a204345ddc3e375b17cf1c96d3412
     subdirs:
       - cardano-ledger
       - cardano-ledger/test
@@ -97,7 +97,7 @@ extra-deps:
       - crypto/test
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: fc164b5a3cbcd239a5803b5d3925205d29837a7c
+    commit: babf1a855e6bc745321b2516837f5cac174b6943
     subdirs:
       - io-sim-classes
       - network-mux


### PR DESCRIPTION
This syncs the dependencies with those that the current HEAD of `cardano-node` (https://github.com/input-output-hk/cardano-node/commit/d402dd42874ae0acbbfb4c42ffb2a773370f1f3d) depends on. These should correspond with those used in `ouroboros-network` and `cardano-byron-proxy`.