### PR TITLE
Align column name with pre-existing plural name

### DIFF
--- a/schema/migration-3-0001-20190816.sql
+++ b/schema/migration-3-0001-20190816.sql
@@ -65,7 +65,7 @@ select
   next_block."hash" as "nextBlockId",
   slot_leader."description" as "createdBy",
   block.size as size,
-	block.tx_count as "transactionCount",
+	block.tx_count as "transactionsCount",
   -- Even though we have epochNo defined in the Slot view,
   -- this is written by the node-client and makes identification
   -- of EBBs simpler, as EBBs don't have a slot_no


### PR DESCRIPTION
This fixes the inconsistency we currently have with _Block.transactionCount_ and _Epoch.transaction**s**Count_

<img width="405" alt="Screenshot 2019-11-27 at 08 43 16" src="https://user-images.githubusercontent.com/303881/69675099-ff9f1580-10f1-11ea-92e7-7a593d2dd381.png">
