### PR TITLE
Fix minor spelling mistake in building-running.md

### DIFF
--- a/doc/building-running.md
+++ b/doc/building-running.md
@@ -23,7 +23,7 @@ they are all at the same level. eg:
 git clone https://github.com/input-output-hk/cardano-byron-proxy
 cd cardano-byron-proxy
 nix-build -A scripts.mainnet.proxy -o mainnet-byron-proxy
-./mainnet-byron-prox
+./mainnet-byron-proxy
 ```
 
 ### Set up and run a local node that connects to the byron proxy


### PR DESCRIPTION
The docs were missing a character in the example to start a local proxy. 