### PR TITLE
remove absolute path in cardano-graphql nix install phase

### DIFF
--- a/nix/cardano-graphql/packages.nix
+++ b/nix/cardano-graphql/packages.nix
@@ -30,7 +30,7 @@
 
       yarn run build
 
-      cp -r /build/''${sourceRoot}/deps/cardano-graphql/dist $out
+      cp -r ../deps/cardano-graphql/dist $out
 
       mkdir -p $out/bin
       cat <<EOF > $out/bin/cardano-graphql


### PR DESCRIPTION
otherwise build fail with
```
 cp: cannot stat '/build/source/deps/cardano-graphql/dist': No such file or directory
```
on my machine.