### PR TITLE
tx-submit: Better handling of hex encoded data

### DIFF
--- a/cardano-tx-submit/CHANGELOG.md
+++ b/cardano-tx-submit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for cardano-tx-submit
 
+## 1.2.? -- ?
+
+* Require content-type `application/cbor` for posted transaction.
+* Add more specific error message when posted transaction is hex encoded.
+
 ## 1.2.2 -- January 2020
 
 * Update dependencies to latest versions.

--- a/cardano-tx-submit/cardano-tx-submit.cabal
+++ b/cardano-tx-submit/cardano-tx-submit.cabal
@@ -66,6 +66,7 @@ library
                       , formatting
                       , generics-sop
                       , hashable
+                      , http-media
                       , iohk-monitoring
                       , io-sim-classes
                       , memory

--- a/cardano-tx-submit/src/Cardano/TxSubmit/Types.hs
+++ b/cardano-tx-submit/src/Cardano/TxSubmit/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators #-}
 module Cardano.TxSubmit.Types
@@ -14,13 +15,16 @@ import           Cardano.Binary (DecoderError)
 import           Data.Aeson (ToJSON (..), Value (..))
 import qualified Data.Aeson as Aeson
 import           Data.ByteString.Char8 (ByteString)
+import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Text (Text)
 
-import           Formatting ((%), build, sformat)
+import           Formatting (build, sformat)
 
 import           GHC.Generics (Generic)
 
-import           Servant (JSON, OctetStream, Post, ReqBody, (:>))
+import           Network.HTTP.Media ((//))
+
+import           Servant (Accept (..), JSON, MimeRender (..), MimeUnrender (..), Post, ReqBody, (:>))
 import           Servant.API.Generic (ToServantApi, (:-))
 
 newtype TxSubmitPort
@@ -48,7 +52,7 @@ convertJson st =
       case st of
         TxSubmitOk -> "No error"
         TxSubmitDecodeHex -> "Provided data was hex encoded and this webapi expects raw binary"
-        TxSubmitDecodeFail err -> sformat ("Decoding provided ByteString failed: " % build) err
+        TxSubmitDecodeFail err -> sformat build err
         TxSubmitFail err -> err
 
 -- | Servant API which provides access to tx submission webapi
@@ -60,6 +64,25 @@ data TxSubmitApiRecord route = TxSubmitApiRecord
   { _txSubmitPost :: route
         :- "submit"
         :> "tx"
-        :> ReqBody '[OctetStream] ByteString
+        :> ReqBody '[CBORStream] ByteString
         :> Post '[JSON] TxSubmitStatus
   } deriving (Generic)
+
+
+
+data CBORStream
+
+instance Accept CBORStream where
+  contentType _ = "application" // "cbor"
+
+instance MimeRender CBORStream ByteString where
+    mimeRender _ = LBS.fromStrict
+
+instance MimeRender CBORStream LBS.ByteString where
+    mimeRender _ = id
+
+instance MimeUnrender CBORStream ByteString where
+    mimeUnrender _ = Right . LBS.toStrict
+
+instance MimeUnrender CBORStream LBS.ByteString where
+    mimeUnrender _ = Right . id

--- a/cardano-tx-submit/src/Cardano/TxSubmit/Types.hs
+++ b/cardano-tx-submit/src/Cardano/TxSubmit/Types.hs
@@ -28,6 +28,7 @@ newtype TxSubmitPort
 
 data TxSubmitStatus
   = TxSubmitOk
+  | TxSubmitDecodeHex
   | TxSubmitDecodeFail DecoderError
   | TxSubmitFail Text
   deriving Eq
@@ -46,7 +47,8 @@ convertJson st =
     failMsg =
       case st of
         TxSubmitOk -> "No error"
-        TxSubmitDecodeFail err -> sformat ("Decoding provided ByetString failed: " % build) err
+        TxSubmitDecodeHex -> "Provided data was hex encoded and this webapi expects raw binary"
+        TxSubmitDecodeFail err -> sformat ("Decoding provided ByteString failed: " % build) err
         TxSubmitFail err -> err
 
 -- | Servant API which provides access to tx submission webapi

--- a/cardano-tx-submit/src/Cardano/TxSubmit/Web.hs
+++ b/cardano-tx-submit/src/Cardano/TxSubmit/Web.hs
@@ -18,6 +18,7 @@ import           Control.Monad.IO.Class (liftIO)
 import           Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
+import qualified Data.Char as Char
 import           Data.Proxy (Proxy (..))
 import           Data.Text (Text)
 
@@ -54,7 +55,10 @@ txSubmitPost
 txSubmitPost tsv trce tx = do
   liftIO $ logInfo trce ("txSubmitPost: tx is " <> textShow (BS.length tx) <> " bytes")
   case decodeByronTx tx of
-    Left err -> pure $ TxSubmitDecodeFail err
+    Left err ->
+      pure $ if BS.all Char.isHexDigit tx
+                then TxSubmitDecodeHex
+                else TxSubmitDecodeFail err
     Right tx1 -> do
       mresp <- liftIO $ submitTx tsv tx1
       liftIO $ logInfo trce (maybe "Success" (\r -> "Error: " <> textShow r) mresp)

--- a/doc/tx-submit.md
+++ b/doc/tx-submit.md
@@ -1,0 +1,33 @@
+# Submitting a Transaction to the tx-submit Web API
+
+Building and running the `cardano-tx-submit-webap` is described in [this document][BuildDoc].
+
+Transactions can be generated using either the `cardano-cli` (in the [cardano-node][NodeRepo]) or
+with the [`js-wasm` library][JS-Wasm].
+
+The transaction needs to be a raw binary (and not encoded as hex or anything else). Once generated
+(in say the file `tx.bin`) the transaction can be submitted to the webapi using:
+
+```
+curl -X POST --header "Content-Type:application/cbor" --data-binary @tx.bin http://[host]:[port]/api/submit/tx
+```
+
+## Possible errors
+
+If the `Content-Type` is not specified as `application/cbor` the webapi server will respond with
+a `415 Unsupported Media Type` HTTP status code.
+
+For other errors, the webapi will respond with a 200 HTTP status code, and a chunk of JSON which
+for the success case will be:
+```
+{ "status": "success"
+, "errorMsg": "No error"
+}
+```
+For the fail case, the `"status"` field will contain `"fail"` and the `"errMsg"` field will contain
+more information.
+
+
+[BuildDoc]: https://github.com/input-output-hk/cardano-explorer/blob/master/doc/building.md
+[NodeRepo]: https://github.com/input-output-hk/cardano-node
+[JS-Wasm]: https://github.com/input-output-hk/js-cardano-wasm

--- a/nix/.stack.nix/cardano-tx-submit.nix
+++ b/nix/.stack.nix/cardano-tx-submit.nix
@@ -77,6 +77,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."formatting" or (buildDepError "formatting"))
           (hsPkgs."generics-sop" or (buildDepError "generics-sop"))
           (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."http-media" or (buildDepError "http-media"))
           (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
           (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
           (hsPkgs."memory" or (buildDepError "memory"))


### PR DESCRIPTION
This should allow the submission of both raw binary and hex encoded
transactions.

Closes: https://github.com/input-output-hk/cardano-explorer/issues/235