### PR TITLE
Merge pull request #246 from input-output-hk/docker-logging

### DIFF
--- a/docker/default.nix
+++ b/docker/default.nix
@@ -64,6 +64,7 @@ let
         cookie.secret = "fake";
       };
     };
+    services.prometheus.alertmanagers = lib.mkForce [];
   };
 
   noauth_configuration = {
@@ -74,6 +75,7 @@ let
         password = "admin";
       };
     };
+    services.prometheus.alertmanagers = lib.mkForce [];
   };
 
   configuration = { config, ... }: {
@@ -211,7 +213,7 @@ let
       name = name;
       text = ''
         #!${stdenv.shell}
-        exec > /var/log/${name}.log
+        exec
         ${text}
       '';
       executable = true;


### PR DESCRIPTION
sends all logs to stdout instead of writing to files in the container. Prevents prometheus from logging alert manager connection errors.