### PR TITLE
Niv bumps

### DIFF
--- a/cardano-tx-submit/src/Cardano/TxSubmit/Metrics.hs
+++ b/cardano-tx-submit/src/Cardano/TxSubmit/Metrics.hs
@@ -24,7 +24,7 @@ registerMetricsServer =
   runRegistryT $ do
     metrics <- makeMetrics
     registry <- RegistryT ask
-    server <- liftIO . async $ runReaderT (unRegistryT $ serveHttpTextMetricsT 8080 []) registry
+    server <- liftIO . async $ runReaderT (unRegistryT $ serveHttpTextMetricsT 8081 []) registry
     pure (metrics, server)
 
 makeMetrics :: RegistryT IO TxSubmitMetrics

--- a/docker/default.nix
+++ b/docker/default.nix
@@ -157,6 +157,12 @@ let
         static_configs = [{ targets = [ "localhost:8080" ]; }];
       }
       {
+        job_name = "tx";
+        scrape_interval = "10s";
+        metrics_path = "/";
+        static_configs = [{ targets = [ "localhost:8081" ]; }];
+      }
+      {
         job_name = "postgres";
         scrape_interval = "10s";
         metrics_path = "/metrics";

--- a/docker/default.nix
+++ b/docker/default.nix
@@ -1,5 +1,6 @@
 { forDockerFile ? false
 , environment ? "testnet"
+, logLocal ? false
 }:
 
 let
@@ -100,7 +101,7 @@ let
     services.cardano-explorer = {
       enable = true;
       cluster = environment;
-      socketPath = "/run/cardano-node/node-core-0.socket";
+      socketPath = "/run/cardano-node/node-core-CoreNodeId 0.socket";
     };
 
     services.postgresql = {
@@ -181,8 +182,8 @@ let
       cardano-explorer-node = {
         serviceConfig.PermissionsStartOnly = "true";
         preStart = ''
-          chgrp cexplorer ${config.services.cardano-exporter.socketPath}
-          chmod g+w ${config.services.cardano-exporter.socketPath}
+          chgrp cexplorer "${config.services.cardano-exporter.socketPath}"
+          chmod g+w "${config.services.cardano-exporter.socketPath}"
         '';
       };
     };
@@ -213,7 +214,7 @@ let
       name = name;
       text = ''
         #!${stdenv.shell}
-        exec
+        exec${lib.optionalString logLocal " > /var/log/${name}.log"}
         ${text}
       '';
       executable = true;

--- a/nix/nixos/cardano-explorer-frontend.nix
+++ b/nix/nixos/cardano-explorer-frontend.nix
@@ -45,12 +45,12 @@ in {
       serviceConfig.PermissionsStartOnly = "true";
       preStart = ''
         for x in {1..24}; do
-          [ -S ${config.services.cardano-exporter.socketPath} ] && break
-          echo loop $x: waiting for ${config.services.cardano-exporter.socketPath} 5 sec...
+          [ -S "${config.services.cardano-exporter.socketPath}" ] && break
+          echo loop $x: waiting for "${config.services.cardano-exporter.socketPath}" 5 sec...
           sleep 5
         done
-        chgrp cexplorer ${config.services.cardano-exporter.socketPath}
-        chmod g+w ${config.services.cardano-exporter.socketPath}
+        chgrp cexplorer "${config.services.cardano-exporter.socketPath}"
+        chmod g+w "${config.services.cardano-exporter.socketPath}"
       '';
     };
   };

--- a/nix/nixos/cardano-exporter-service.nix
+++ b/nix/nixos/cardano-exporter-service.nix
@@ -89,7 +89,7 @@ in {
         then
           echo "You must set \$CARDANO_NODE_SOCKET_PATH"
           exit 1
-        fi'' else "export CARDANO_NODE_SOCKET_PATH=${cfg.socketPath}"}
+        fi'' else "export CARDANO_NODE_SOCKET_PATH=\"${cfg.socketPath}\""}
 
         export PATH=${lib.makeBinPath [ self.cardano-explorer-node self.haskellPackages.cardano-explorer-db.components.exes.cardano-explorer-db-tool pkgs.postgresql ]}:$PATH
 
@@ -103,7 +103,7 @@ in {
         exec cardano-explorer-node \
           --config ${configFile} \
           --genesis-file ${envConfig.genesisFile} \
-          --socket-path $CARDANO_NODE_SOCKET_PATH \
+          --socket-path "$CARDANO_NODE_SOCKET_PATH" \
           --schema-dir ${../../schema}
       '';
     };

--- a/nix/nixos/cardano-tx-submitter.nix
+++ b/nix/nixos/cardano-tx-submitter.nix
@@ -39,7 +39,7 @@ in {
       then
         echo "You must set \$CARDANO_NODE_SOCKET_PATH"
         exit 1
-      fi'' else "export CARDANO_NODE_SOCKET_PATH=${cfg.socketPath}"}
+      fi'' else "export \"CARDANO_NODE_SOCKET_PATH=${cfg.socketPath}\""}
       exec ${self.cardano-tx-submit-webapi}/bin/cardano-tx-submit-webapi --socket-path "$CARDANO_NODE_SOCKET_PATH" \
             --genesis-file ${envConfig.genesisFile} \
             --port ${toString config.services.cardano-tx-submit-webapi.port} \

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "3b04ff7cadb369354fbdee63e88c4d2602cb44c2",
-        "sha256": "0b7c92fpk06yjwgpcrngf2s33260v5h9pr2w0pxl854xj99g0faf",
+        "rev": "b69430570ccb013c8ad01625483e275e9f8039b7",
+        "sha256": "1j1ssiyw1gf7mr23yczzr0k34yqwy0ag6ydl4zyw5zsfwgacdc6g",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/3b04ff7cadb369354fbdee63e88c4d2602cb44c2.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/b69430570ccb013c8ad01625483e275e9f8039b7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "gitignore": {
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "75a17d94a203631293e634cb0690b8a582bf44e3",
-        "sha256": "0m55slpr55fycw5190c3c12q0zhqybfikgqallcl9wakldk5728n",
+        "rev": "77a765ba074949cb56302c04ff91227fd6f05303",
+        "sha256": "1h22ac32xd92p28sdkryhak7q6kc19isndbjx9jrkwa2dxl3hbbi",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/75a17d94a203631293e634cb0690b8a582bf44e3.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/77a765ba074949cb56302c04ff91227fd6f05303.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
* Fixes socket path quoting to work with socket paths with spaces in them
* Updates niv pin for cardano-node and iohk-nix
* changes hard-coded tx submit monitoring port to 8081 to not conflict with hard coded exporter port