### PR TITLE
 Update to the latest consensus and ledger lib versions.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -63,7 +63,7 @@ package test-protocols
 package typed-protocols
   tests: False
 
-package typed-protocols-cbor
+package typed-protocols-examples
   tests: False
 
 package lobemo-backend-monitoring
@@ -101,12 +101,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 00487726c4bc21b4744e59d913334ebfeac7d68e
+  tag: fa7a16291d3e93b068d9b13620fc81c88b5600f0
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 00487726c4bc21b4744e59d913334ebfeac7d68e
+  tag: fa7a16291d3e93b068d9b13620fc81c88b5600f0
   subdir: test
 
 source-repository-package
@@ -117,73 +117,73 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
+  tag: 49b347d892d82dce23eb692722649cd8a1149406
   subdir: contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
+  tag: 49b347d892d82dce23eb692722649cd8a1149406
   subdir: iohk-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
+  tag: 49b347d892d82dce23eb692722649cd8a1149406
   subdir: plugins/backend-aggregation
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
+  tag: 49b347d892d82dce23eb692722649cd8a1149406
   subdir: plugins/backend-editor
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
+  tag: 49b347d892d82dce23eb692722649cd8a1149406
   subdir: plugins/backend-ekg
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
+  tag: 49b347d892d82dce23eb692722649cd8a1149406
   subdir: plugins/backend-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
+  tag: 49b347d892d82dce23eb692722649cd8a1149406
   subdir: plugins/scribe-systemd
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
+  tag: 49b347d892d82dce23eb692722649cd8a1149406
   subdir: tracer-transformers
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 965b8b143632faea16680a195e6de57091382700
+  tag: 3c2791584d3f43aa18e9cc13c490239b4c3dcbd2
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 965b8b143632faea16680a195e6de57091382700
+  tag: 3c2791584d3f43aa18e9cc13c490239b4c3dcbd2
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 965b8b143632faea16680a195e6de57091382700
+  tag: 3c2791584d3f43aa18e9cc13c490239b4c3dcbd2
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 965b8b143632faea16680a195e6de57091382700
+  tag: 3c2791584d3f43aa18e9cc13c490239b4c3dcbd2
   subdir: slotting
 
 source-repository-package
@@ -194,83 +194,89 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: f27e8b66a393f0b7da1893889dcea07da0fe4dec
+  tag: 318f5a1594a23aedadb3977ddd5a32230c8be4fe
   subdir: byron/semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: f27e8b66a393f0b7da1893889dcea07da0fe4dec
+  tag: 318f5a1594a23aedadb3977ddd5a32230c8be4fe
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: f27e8b66a393f0b7da1893889dcea07da0fe4dec
+  tag: 318f5a1594a23aedadb3977ddd5a32230c8be4fe
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: c62e2eeba5756898cbf59732fccd6a83a4065c18
+  tag: 86f0cb4705f46307e4c89e7ef4c90142882cce54
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: c62e2eeba5756898cbf59732fccd6a83a4065c18
+  tag: 86f0cb4705f46307e4c89e7ef4c90142882cce54
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: c62e2eeba5756898cbf59732fccd6a83a4065c18
+  tag: 86f0cb4705f46307e4c89e7ef4c90142882cce54
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: c62e2eeba5756898cbf59732fccd6a83a4065c18
+  tag: 86f0cb4705f46307e4c89e7ef4c90142882cce54
   subdir: crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a43961c1133b9e1b0826f3d4d1bc5b93819037d6
+  tag: 5f77e24c2263560ad58b9ba092c8cfed174675ae
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a43961c1133b9e1b0826f3d4d1bc5b93819037d6
+  tag: 5f77e24c2263560ad58b9ba092c8cfed174675ae
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a43961c1133b9e1b0826f3d4d1bc5b93819037d6
+  tag: 5f77e24c2263560ad58b9ba092c8cfed174675ae
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a43961c1133b9e1b0826f3d4d1bc5b93819037d6
+  tag: 5f77e24c2263560ad58b9ba092c8cfed174675ae
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a43961c1133b9e1b0826f3d4d1bc5b93819037d6
+  tag: 5f77e24c2263560ad58b9ba092c8cfed174675ae
+  subdir: ouroboros-network-framework
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: 5f77e24c2263560ad58b9ba092c8cfed174675ae
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a43961c1133b9e1b0826f3d4d1bc5b93819037d6
+  tag: 5f77e24c2263560ad58b9ba092c8cfed174675ae
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a43961c1133b9e1b0826f3d4d1bc5b93819037d6
-  subdir: typed-protocols-cbor
+  tag: 5f77e24c2263560ad58b9ba092c8cfed174675ae
+  subdir: typed-protocols-examples

--- a/cabal.project
+++ b/cabal.project
@@ -90,7 +90,7 @@ package delegation
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-crypto
-  tag: 4590efa638397e952a51a8994b5543e4ea3c1ecd
+  tag: 2547ad1e80aeabca2899951601079408becbc92c
 
 source-repository-package
   type: git
@@ -101,12 +101,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: fa7a16291d3e93b068d9b13620fc81c88b5600f0
+  tag: 57fcc83702b91e0a7aecdb32c99ab1d8c1c444d0
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: fa7a16291d3e93b068d9b13620fc81c88b5600f0
+  tag: 57fcc83702b91e0a7aecdb32c99ab1d8c1c444d0
   subdir: test
 
 source-repository-package
@@ -165,25 +165,25 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 3c2791584d3f43aa18e9cc13c490239b4c3dcbd2
+  tag: a7b403c1762a6a122a691df816c26563b7e547f8
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 3c2791584d3f43aa18e9cc13c490239b4c3dcbd2
+  tag: a7b403c1762a6a122a691df816c26563b7e547f8
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 3c2791584d3f43aa18e9cc13c490239b4c3dcbd2
+  tag: a7b403c1762a6a122a691df816c26563b7e547f8
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 3c2791584d3f43aa18e9cc13c490239b4c3dcbd2
+  tag: a7b403c1762a6a122a691df816c26563b7e547f8
   subdir: slotting
 
 source-repository-package
@@ -212,25 +212,25 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 86f0cb4705f46307e4c89e7ef4c90142882cce54
+  tag: 172b49ff1b6456851f10ae18f920fbfa733be0b0
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 86f0cb4705f46307e4c89e7ef4c90142882cce54
+  tag: 172b49ff1b6456851f10ae18f920fbfa733be0b0
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 86f0cb4705f46307e4c89e7ef4c90142882cce54
+  tag: 172b49ff1b6456851f10ae18f920fbfa733be0b0
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 86f0cb4705f46307e4c89e7ef4c90142882cce54
+  tag: 172b49ff1b6456851f10ae18f920fbfa733be0b0
   subdir: crypto/test
 
 source-repository-package

--- a/cardano-explorer-db/src/Explorer/DB/Run.hs
+++ b/cardano-explorer-db/src/Explorer/DB/Run.hs
@@ -23,8 +23,8 @@ import           Control.Tracer (traceWith)
 import           Control.Monad.IO.Class (liftIO)
 
 import qualified Data.ByteString.Char8 as BS
-import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Text (Text)
+import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy.IO as LT
 import qualified Data.Text.Lazy.Builder as LT
 
@@ -94,7 +94,9 @@ runIohkLogging tracer action =
     toIohkLog :: Loc -> LogSource -> LogLevel -> LogStr -> IO ()
     toIohkLog _loc _src level msg = do
       meta <- mkLOMeta (toIohkSeverity level) Public
-      traceWith tracer $ LogObject ["explorer-db"] meta (LogStructured . LBS.fromStrict $ fromLogStr msg)
+      traceWith tracer $
+        LogObject ["explorer-db"] meta
+                  (LogMessage . T.decodeLatin1 $ fromLogStr msg)
 
     toIohkSeverity :: LogLevel -> Severity
     toIohkSeverity =

--- a/cardano-explorer-node/cardano-explorer-node.cabal
+++ b/cardano-explorer-node/cardano-explorer-node.cabal
@@ -73,6 +73,7 @@ library
                       , network
                       , ouroboros-consensus
                       , ouroboros-network
+                      , ouroboros-network-framework
                       , persistent
                       , prometheus
                       , serialise
@@ -82,7 +83,6 @@ library
                       , transformers
                       , transformers-except
                       , typed-protocols
-                      , typed-protocols-cbor
                       , yaml
 
 executable cardano-explorer-node
@@ -116,10 +116,10 @@ executable cardano-explorer-node
                       , network
                       , optparse-applicative
                       , ouroboros-network
+                      , ouroboros-network-framework
                       , serialise
                       , text
                       , typed-protocols
-                      , typed-protocols-cbor
 
 test-suite test
   default-language:     Haskell2010

--- a/cardano-explorer-node/src/Explorer/Node.hs
+++ b/cardano-explorer-node/src/Explorer/Node.hs
@@ -302,8 +302,8 @@ getCurrentTipBlockNo = do
   where
     convert :: DB.Block -> BlockNo
     convert blk =
-      case DB.blockSlotNo blk of
-        Just slot -> BlockNo slot
+      case DB.blockBlockNo blk of
+        Just blockno -> BlockNo blockno
         Nothing -> genesisBlockNo
 
 -- | A 'LocalTxSubmissionClient' that submits transactions reading them from

--- a/cardano-explorer-node/src/Explorer/Node.hs
+++ b/cardano-explorer-node/src/Explorer/Node.hs
@@ -84,7 +84,7 @@ import           Ouroboros.Consensus.Node.Run.Abstract (RunNode, nodeDecodeBlock
 import           Ouroboros.Consensus.Node.ErrorPolicy (consensusErrorPolicy)
 import           Ouroboros.Consensus.Protocol (NodeConfig, Protocol (..))
 
-import           Ouroboros.Network.Point (WithOrigin (..), withOrigin, fromWithOrigin)
+import           Ouroboros.Network.Point (WithOrigin (..), withOrigin)
 import           Ouroboros.Network.Block (Point (..), SlotNo (..),
                     Tip, getTipBlockNo,
                     decodePoint, encodePoint, genesisPoint, blockNo,
@@ -402,7 +402,7 @@ chainSyncClient trce metrics latestPoints currentTip actionQueue =
                 Gauge.set (withOrigin 0 (fromIntegral . unBlockNo) (getTipBlockNo tip))
                           (mNodeHeight metrics)
                 newSize <- atomically $ do
-                  writeDbActionQueue actionQueue $ DbApplyBlock blk (fromWithOrigin 0 (getTipBlockNo tip))
+                  writeDbActionQueue actionQueue $ DbApplyBlock blk tip
                   lengthDbActionQueue actionQueue
                 Gauge.set (fromIntegral newSize) $ mQueuePostWrite metrics
                 pure $ finish (At (blockNo blk)) tip

--- a/cardano-explorer-node/src/Explorer/Node/Plugin.hs
+++ b/cardano-explorer-node/src/Explorer/Node/Plugin.hs
@@ -13,7 +13,7 @@ import           Database.Persist.Sql (SqlBackend)
 
 import           Explorer.Node.Error
 
-import           Ouroboros.Network.Block (BlockNo (..), Point (..))
+import           Ouroboros.Network.Block (Point (..), Tip)
 import           Ouroboros.Consensus.Ledger.Byron (ByronBlock)
 
 
@@ -42,7 +42,7 @@ data ExplorerNodePlugin = ExplorerNodePlugin
     -- all subsequent blocks.
     -- Blocks (including epoch boundary blocks) are called in sequence from the oldest to the newest.
   , plugInsertBlock
-        :: [Trace IO Text -> ByronBlock -> BlockNo -> ReaderT SqlBackend (LoggingT IO) (Either ExplorerNodeError ())]
+        :: [Trace IO Text -> ByronBlock -> Tip ByronBlock -> ReaderT SqlBackend (LoggingT IO) (Either ExplorerNodeError ())]
 
     -- Rollback to the specified SlotNumber/HeaderHash.
   , plugRollbackBlock

--- a/cardano-tx-submit/cardano-tx-submit.cabal
+++ b/cardano-tx-submit/cardano-tx-submit.cabal
@@ -76,6 +76,7 @@ library
                       , network
                       , ouroboros-consensus
                       , ouroboros-network
+                      , ouroboros-network-framework
                       , prometheus
                       , serialise
                       , servant
@@ -85,7 +86,6 @@ library
                       , transformers
                       , transformers-except
                       , typed-protocols
-                      , typed-protocols-cbor
                       , warp
                       , yaml
 

--- a/cardano-tx-submit/src/Cardano/TxSubmit/ErrorRender.hs
+++ b/cardano-tx-submit/src/Cardano/TxSubmit/ErrorRender.hs
@@ -10,13 +10,12 @@ module Cardano.TxSubmit.ErrorRender
 
 import           Cardano.Chain.UTxO.Validation (TxValidationError (..), UTxOValidationError (..))
 import           Cardano.Chain.UTxO.UTxO (UTxOError(..))
+import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr (..))
 
 import           Data.Text (Text)
 import qualified Data.Text as Text
 
 import           Formatting ((%), build, sformat, stext)
-
-import           Ouroboros.Consensus.Ledger.Byron.Auxiliary (ApplyMempoolPayloadErr (..))
 
 
 renderApplyMempoolPayloadErr :: ApplyMempoolPayloadErr -> Text

--- a/cardano-tx-submit/src/Cardano/TxSubmit/Node.hs
+++ b/cardano-tx-submit/src/Cardano/TxSubmit/Node.hs
@@ -54,8 +54,6 @@ import           Data.Void (Void)
 import           Network.Socket (SockAddr (..))
 
 import           Network.TypedProtocol.Channel (Channel)
-import           Network.TypedProtocol.Codec (Codec)
-import           Network.TypedProtocol.Codec.Cbor (DeserialiseFailure)
 import           Network.TypedProtocol.Driver (runPeer)
 
 import           Ouroboros.Consensus.Ledger.Abstract (BlockProtocol)
@@ -67,6 +65,7 @@ import           Ouroboros.Consensus.Node.Run.Abstract (RunNode, nodeDecodeGenTx
 import           Ouroboros.Consensus.Node.ErrorPolicy (consensusErrorPolicy)
 import           Ouroboros.Consensus.Protocol (NodeConfig, Protocol (..))
 
+import           Ouroboros.Network.Codec (Codec, DeserialiseFailure)
 import           Ouroboros.Network.Mux (AppType (..), OuroborosApplication (..))
 import           Ouroboros.Network.NodeToClient (ErrorPolicyTrace (..), IPSubscriptionTarget (..),
                     LocalAddresses (..), NodeToClientProtocols (..), NetworkIPSubscriptionTracers (..),

--- a/cardano-tx-submit/src/Cardano/TxSubmit/Tx.hs
+++ b/cardano-tx-submit/src/Cardano/TxSubmit/Tx.hs
@@ -17,7 +17,7 @@ import           Control.Monad.Class.MonadSTM.Strict (StrictTMVar,
                     atomically, newEmptyTMVarM, putTMVar, takeTMVar)
 
 import           Ouroboros.Consensus.Ledger.Byron (ByronBlock (..), GenTx (..))
-import           Ouroboros.Consensus.Ledger.Byron.Auxiliary (ApplyMempoolPayloadErr)
+import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr)
 
 -- The type of 'reject' (determined by ouroboros-network) is currently 'Maybe String'.
 -- Hopefully that will be fixed to make it a concrete type.

--- a/cardano-tx-submit/src/Cardano/TxSubmit/Types.hs
+++ b/cardano-tx-submit/src/Cardano/TxSubmit/Types.hs
@@ -13,6 +13,7 @@ module Cardano.TxSubmit.Types
 
 import           Cardano.Binary (DecoderError)
 import qualified Cardano.Chain.UTxO as Utxo
+import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr)
 import           Cardano.TxSubmit.ErrorRender
 
 import           Data.Aeson (ToJSON (..), Value (..))
@@ -26,8 +27,6 @@ import           Formatting ((%), build, sformat)
 import           GHC.Generics (Generic)
 
 import           Network.HTTP.Media ((//))
-
-import           Ouroboros.Consensus.Ledger.Byron.Auxiliary (ApplyMempoolPayloadErr)
 
 import           Servant (Accept (..), JSON, MimeRender (..), MimeUnrender (..), Post, ReqBody, (:>))
 import           Servant.API.Generic (ToServantApi, (:-))

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -79,8 +79,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "965b8b143632faea16680a195e6de57091382700";
-      sha256 = "0x3cy5xa9mqdqnavs45assmmcrzw07qcwsv95capqwa6awz1plhh";
+      rev = "a7b403c1762a6a122a691df816c26563b7e547f8";
+      sha256 = "0j87xb20xkl2h5vbqhn9af7dqjwwcbp60nwsp1yablzv295gnxwi";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -43,7 +43,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-crypto-class"; version = "2.0.0"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK";
@@ -90,8 +90,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "965b8b143632faea16680a195e6de57091382700";
-      sha256 = "0x3cy5xa9mqdqnavs45assmmcrzw07qcwsv95capqwa6awz1plhh";
+      rev = "a7b403c1762a6a122a691df816c26563b7e547f8";
+      sha256 = "0j87xb20xkl2h5vbqhn9af7dqjwwcbp60nwsp1yablzv295gnxwi";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -43,7 +43,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-crypto-test"; version = "1.3.0"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2018 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK";
@@ -75,8 +75,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "c62e2eeba5756898cbf59732fccd6a83a4065c18";
-      sha256 = "04s2dp5dyikm2pxfphiyh429pckkg06dqx3sl4bbzvg6x5qfqvbn";
+      rev = "172b49ff1b6456851f10ae18f920fbfa733be0b0";
+      sha256 = "1515jhmhv22w8v2rqd2mckbsdd1vzaqdj9v8zdjsrrb1j5g59900";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -43,7 +43,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-crypto-wrapper"; version = "1.3.0"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK";
@@ -101,8 +101,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "c62e2eeba5756898cbf59732fccd6a83a4065c18";
-      sha256 = "04s2dp5dyikm2pxfphiyh429pckkg06dqx3sl4bbzvg6x5qfqvbn";
+      rev = "172b49ff1b6456851f10ae18f920fbfa733be0b0";
+      sha256 = "1515jhmhv22w8v2rqd2mckbsdd1vzaqdj9v8zdjsrrb1j5g59900";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-explorer-node.nix
+++ b/nix/.stack.nix/cardano-explorer-node.nix
@@ -85,6 +85,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."network" or (buildDepError "network"))
           (hsPkgs."ouroboros-consensus" or (buildDepError "ouroboros-consensus"))
           (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
+          (hsPkgs."ouroboros-network-framework" or (buildDepError "ouroboros-network-framework"))
           (hsPkgs."persistent" or (buildDepError "persistent"))
           (hsPkgs."prometheus" or (buildDepError "prometheus"))
           (hsPkgs."serialise" or (buildDepError "serialise"))
@@ -94,7 +95,6 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."transformers" or (buildDepError "transformers"))
           (hsPkgs."transformers-except" or (buildDepError "transformers-except"))
           (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
-          (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
           (hsPkgs."yaml" or (buildDepError "yaml"))
           ];
         buildable = true;
@@ -119,10 +119,10 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."network" or (buildDepError "network"))
             (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
             (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
+            (hsPkgs."ouroboros-network-framework" or (buildDepError "ouroboros-network-framework"))
             (hsPkgs."serialise" or (buildDepError "serialise"))
             (hsPkgs."text" or (buildDepError "text"))
             (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
-            (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
             ];
           buildable = true;
           };

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -43,7 +43,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-ledger-test"; version = "1.3.0"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2018 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK";
@@ -96,8 +96,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "c62e2eeba5756898cbf59732fccd6a83a4065c18";
-      sha256 = "04s2dp5dyikm2pxfphiyh429pckkg06dqx3sl4bbzvg6x5qfqvbn";
+      rev = "172b49ff1b6456851f10ae18f920fbfa733be0b0";
+      sha256 = "1515jhmhv22w8v2rqd2mckbsdd1vzaqdj9v8zdjsrrb1j5g59900";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -43,7 +43,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-ledger"; version = "0.1.0.0"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2018 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK";
@@ -58,6 +58,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
           (hsPkgs."base58-bytestring" or (buildDepError "base58-bytestring"))
           (hsPkgs."base64-bytestring-type" or (buildDepError "base64-bytestring-type"))
           (hsPkgs."bimap" or (buildDepError "bimap"))
@@ -68,6 +69,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
           (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
           (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
           (hsPkgs."containers" or (buildDepError "containers"))
           (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
           (hsPkgs."concurrency" or (buildDepError "concurrency"))
@@ -160,8 +162,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "c62e2eeba5756898cbf59732fccd6a83a4065c18";
-      sha256 = "04s2dp5dyikm2pxfphiyh429pckkg06dqx3sl4bbzvg6x5qfqvbn";
+      rev = "172b49ff1b6456851f10ae18f920fbfa733be0b0";
+      sha256 = "1515jhmhv22w8v2rqd2mckbsdd1vzaqdj9v8zdjsrrb1j5g59900";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -83,8 +83,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "00487726c4bc21b4744e59d913334ebfeac7d68e";
-      sha256 = "0v4fcq5kdd2r5dgwys8kv46ff33qp756n26ycxrca10wq14zkwm5";
+      rev = "57fcc83702b91e0a7aecdb32c99ab1d8c1c444d0";
+      sha256 = "1q2pz7qx9l4frnifilv0jqz8i4y3q0jwlip4m22z0ldiz5iasmln";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -116,7 +116,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "00487726c4bc21b4744e59d913334ebfeac7d68e";
-      sha256 = "0v4fcq5kdd2r5dgwys8kv46ff33qp756n26ycxrca10wq14zkwm5";
+      rev = "57fcc83702b91e0a7aecdb32c99ab1d8c1c444d0";
+      sha256 = "1q2pz7qx9l4frnifilv0jqz8i4y3q0jwlip4m22z0ldiz5iasmln";
       });
     }

--- a/nix/.stack.nix/cardano-slotting.nix
+++ b/nix/.stack.nix/cardano-slotting.nix
@@ -43,7 +43,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-slotting"; version = "0.1.0.0"; };
-      license = "NONE";
+      license = "Apache-2.0";
       copyright = "IOHK";
       maintainer = "formal.methods@iohk.io";
       author = "IOHK Formal Methods Team";
@@ -73,8 +73,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "965b8b143632faea16680a195e6de57091382700";
-      sha256 = "0x3cy5xa9mqdqnavs45assmmcrzw07qcwsv95capqwa6awz1plhh";
+      rev = "a7b403c1762a6a122a691df816c26563b7e547f8";
+      sha256 = "0j87xb20xkl2h5vbqhn9af7dqjwwcbp60nwsp1yablzv295gnxwi";
       });
     postUnpack = "sourceRoot+=/slotting; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-tx-submit.nix
+++ b/nix/.stack.nix/cardano-tx-submit.nix
@@ -86,6 +86,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."network" or (buildDepError "network"))
           (hsPkgs."ouroboros-consensus" or (buildDepError "ouroboros-consensus"))
           (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
+          (hsPkgs."ouroboros-network-framework" or (buildDepError "ouroboros-network-framework"))
           (hsPkgs."prometheus" or (buildDepError "prometheus"))
           (hsPkgs."serialise" or (buildDepError "serialise"))
           (hsPkgs."servant" or (buildDepError "servant"))
@@ -95,7 +96,6 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."transformers" or (buildDepError "transformers"))
           (hsPkgs."transformers-except" or (buildDepError "transformers-except"))
           (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
-          (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
           (hsPkgs."warp" or (buildDepError "warp"))
           (hsPkgs."yaml" or (buildDepError "yaml"))
           ];

--- a/nix/.stack.nix/cborg.nix
+++ b/nix/.stack.nix/cborg.nix
@@ -39,70 +39,70 @@ let
       '';
 in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = { development = false; };
+    flags = { optimize-gmp = true; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-binary"; version = "1.5.0"; };
-      license = "Apache-2.0";
-      copyright = "2019 IOHK";
-      maintainer = "operations@iohk.io";
-      author = "IOHK";
+      identifier = { name = "cborg"; version = "0.2.2.1"; };
+      license = "BSD-3-Clause";
+      copyright = "2015-2019 Duncan Coutts,\n2015-2019 Well-Typed LLP,\n2015 IRIS Connect Ltd";
+      maintainer = "duncan@community.haskell.org, ben@smart-cactus.org";
+      author = "Duncan Coutts";
       homepage = "";
       url = "";
-      synopsis = "Binary serialization for Cardano";
-      description = "This package includes the binary serialization format for Cardano";
+      synopsis = "Concise Binary Object Representation (CBOR)";
+      description = "This package provides an efficient implementation of the Concise\nBinary Object Representation (CBOR), as specified by\n[RFC 7049](https://tools.ietf.org/html/rfc7049).\n\nIf you are looking for a library for serialisation of Haskell values,\nhave a look at the [serialise](/package/serialise) package, which is\nbuilt upon this library.\n\nAn implementation of the standard bijection between CBOR and JSON is\nprovided by the [cborg-json](/package/cborg-json) package. Also see\n[cbor-tool](/package/cbor-tool) for a convenient command-line utility\nfor working with CBOR data.\n\nThis package was formerly known as @binary-serialise-cbor@.";
       buildType = "Simple";
       isLocal = true;
       };
     components = {
       "library" = {
-        depends = [
+        depends = ([
+          (hsPkgs."array" or (buildDepError "array"))
           (hsPkgs."base" or (buildDepError "base"))
-          (hsPkgs."aeson" or (buildDepError "aeson"))
           (hsPkgs."bytestring" or (buildDepError "bytestring"))
-          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
-          (hsPkgs."cborg" or (buildDepError "cborg"))
           (hsPkgs."containers" or (buildDepError "containers"))
-          (hsPkgs."digest" or (buildDepError "digest"))
-          (hsPkgs."formatting" or (buildDepError "formatting"))
-          (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
-          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
-          (hsPkgs."tagged" or (buildDepError "tagged"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."ghc-prim" or (buildDepError "ghc-prim"))
+          (hsPkgs."half" or (buildDepError "half"))
+          (hsPkgs."primitive" or (buildDepError "primitive"))
           (hsPkgs."text" or (buildDepError "text"))
-          (hsPkgs."time" or (buildDepError "time"))
-          (hsPkgs."vector" or (buildDepError "vector"))
+          ] ++ (pkgs.lib).optional (flags.optimize-gmp) (hsPkgs."integer-gmp" or (buildDepError "integer-gmp"))) ++ (pkgs.lib).optionals (!(compiler.isGhc && (compiler.version).ge "8.0")) [
+          (hsPkgs."fail" or (buildDepError "fail"))
+          (hsPkgs."semigroups" or (buildDepError "semigroups"))
           ];
         buildable = true;
         };
       tests = {
-        "test" = {
+        "tests" = {
           depends = [
+            (hsPkgs."array" or (buildDepError "array"))
             (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."base-orphans" or (buildDepError "base-orphans"))
             (hsPkgs."bytestring" or (buildDepError "bytestring"))
-            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
-            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
-            (hsPkgs."cardano-prelude-test" or (buildDepError "cardano-prelude-test"))
-            (hsPkgs."cborg" or (buildDepError "cborg"))
-            (hsPkgs."containers" or (buildDepError "containers"))
-            (hsPkgs."formatting" or (buildDepError "formatting"))
-            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
-            (hsPkgs."hspec" or (buildDepError "hspec"))
-            (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
-            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
-            (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
-            (hsPkgs."tagged" or (buildDepError "tagged"))
             (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."base64-bytestring" or (buildDepError "base64-bytestring"))
+            (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+            (hsPkgs."deepseq" or (buildDepError "deepseq"))
+            (hsPkgs."half" or (buildDepError "half"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."scientific" or (buildDepError "scientific"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
             (hsPkgs."vector" or (buildDepError "vector"))
-            ];
+            ] ++ (pkgs.lib).optional (!(compiler.isGhc && (compiler.version).ge "8.0")) (hsPkgs."fail" or (buildDepError "fail"));
           buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-base";
-      rev = "a7b403c1762a6a122a691df816c26563b7e547f8";
-      sha256 = "0j87xb20xkl2h5vbqhn9af7dqjwwcbp60nwsp1yablzv295gnxwi";
+      url = "https://github.com/well-typed/cborg";
+      rev = "42a83192749774268337258f4f94c97584b80ca6";
+      sha256 = "1smjni26p14p41d1zjpk59jn28zfnpblin5rq6ipp4cjpjiril04";
       });
-    postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
+    postUnpack = "sourceRoot+=/cborg; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -65,8 +65,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "dd30455144e11efb435619383ba84ce02aee720d";
-      sha256 = "1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5";
+      rev = "49b347d892d82dce23eb692722649cd8a1149406";
+      sha256 = "0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-blockchain.nix
+++ b/nix/.stack.nix/cs-blockchain.nix
@@ -92,8 +92,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "f27e8b66a393f0b7da1893889dcea07da0fe4dec";
-      sha256 = "1f1r1vidnlyka800jpm9z2myrggasqyzw0aw97q8vw81sh72l51s";
+      rev = "318f5a1594a23aedadb3977ddd5a32230c8be4fe";
+      sha256 = "09zmg09v6r9jr1jl2xim29nc8g4ys2pjisbm66xj2409znn5n19q";
       });
     postUnpack = "sourceRoot+=/byron/chain/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -112,8 +112,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "f27e8b66a393f0b7da1893889dcea07da0fe4dec";
-      sha256 = "1f1r1vidnlyka800jpm9z2myrggasqyzw0aw97q8vw81sh72l51s";
+      rev = "318f5a1594a23aedadb3977ddd5a32230c8be4fe";
+      sha256 = "09zmg09v6r9jr1jl2xim29nc8g4ys2pjisbm66xj2409znn5n19q";
       });
     postUnpack = "sourceRoot+=/byron/ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -18,7 +18,7 @@
         "persistent-template" = (((hackage.persistent-template)."2.8.2.3").revisions).default;
         "prometheus" = (((hackage.prometheus)."2.1.2").revisions).default;
         "pvss" = (((hackage.pvss)."0.2.0").revisions).default;
-        "tasty-hedgehog" = (((hackage.tasty-hedgehog)."1.0.0.1").revisions).default;
+        "tasty-hedgehog" = (((hackage.tasty-hedgehog)."1.0.0.2").revisions).default;
         "text-zipper" = (((hackage.text-zipper)."0.10.1").revisions).default;
         "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
         "word-wrap" = (((hackage.word-wrap)."0.4.1").revisions).default;
@@ -37,10 +37,9 @@
         "http-api-data" = (((hackage.http-api-data)."0.4.1.1").revisions).default;
         "time-compat" = (((hackage.time-compat)."1.9.2.2").revisions).default;
         "base58-bytestring" = (((hackage.base58-bytestring)."0.1.0").revisions).default;
-        "hedgehog" = (((hackage.hedgehog)."1.0").revisions).default;
+        "hedgehog" = (((hackage.hedgehog)."1.0.2").revisions).default;
         "micro-recursion-schemes" = (((hackage.micro-recursion-schemes)."5.0.2.2").revisions).default;
         "streaming-binary" = (((hackage.streaming-binary)."0.3.0.1").revisions).default;
-        "cborg" = (((hackage.cborg)."0.2.2.0").revisions).default;
         "canonical-json" = (((hackage.canonical-json)."0.6.0.0").revisions).default;
         cardano-explorer-db = ./cardano-explorer-db.nix;
         cardano-explorer-db-test = ./cardano-explorer-db-test.nix;
@@ -77,8 +76,10 @@
         ouroboros-network = ./ouroboros-network.nix;
         ouroboros-consensus = ./ouroboros-consensus.nix;
         typed-protocols = ./typed-protocols.nix;
-        typed-protocols-cbor = ./typed-protocols-cbor.nix;
+        ouroboros-network-framework = ./ouroboros-network-framework.nix;
+        typed-protocols-examples = ./typed-protocols-examples.nix;
         cardano-crypto = ./cardano-crypto.nix;
+        cborg = ./cborg.nix;
         };
       compiler.version = "8.6.5";
       compiler.nix-name = "ghc865";

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -70,8 +70,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "a43961c1133b9e1b0826f3d4d1bc5b93819037d6";
-      sha256 = "0pj3jnc8wmyx91r22idmkz4jw3mayady4c4wxy45w0lhgksr89x3";
+      rev = "5f77e24c2263560ad58b9ba092c8cfed174675ae";
+      sha256 = "00bm1fa83lc6jgh36mwr4zymzg9hvmq68y2hm4klk8c8gn7vwqqb";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/io-sim.nix
+++ b/nix/.stack.nix/io-sim.nix
@@ -86,8 +86,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "a43961c1133b9e1b0826f3d4d1bc5b93819037d6";
-      sha256 = "0pj3jnc8wmyx91r22idmkz4jw3mayady4c4wxy45w0lhgksr89x3";
+      rev = "5f77e24c2263560ad58b9ba092c8cfed174675ae";
+      sha256 = "00bm1fa83lc6jgh36mwr4zymzg9hvmq68y2hm4klk8c8gn7vwqqb";
       });
     postUnpack = "sourceRoot+=/io-sim; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -137,8 +137,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "dd30455144e11efb435619383ba84ce02aee720d";
-      sha256 = "1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5";
+      rev = "49b347d892d82dce23eb692722649cd8a1149406";
+      sha256 = "0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-aggregation.nix
+++ b/nix/.stack.nix/lobemo-backend-aggregation.nix
@@ -78,8 +78,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "dd30455144e11efb435619383ba84ce02aee720d";
-      sha256 = "1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5";
+      rev = "49b347d892d82dce23eb692722649cd8a1149406";
+      sha256 = "0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6";
       });
     postUnpack = "sourceRoot+=/plugins/backend-aggregation; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-editor.nix
+++ b/nix/.stack.nix/lobemo-backend-editor.nix
@@ -79,8 +79,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "dd30455144e11efb435619383ba84ce02aee720d";
-      sha256 = "1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5";
+      rev = "49b347d892d82dce23eb692722649cd8a1149406";
+      sha256 = "0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6";
       });
     postUnpack = "sourceRoot+=/plugins/backend-editor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-ekg.nix
+++ b/nix/.stack.nix/lobemo-backend-ekg.nix
@@ -78,8 +78,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "dd30455144e11efb435619383ba84ce02aee720d";
-      sha256 = "1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5";
+      rev = "49b347d892d82dce23eb692722649cd8a1149406";
+      sha256 = "0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6";
       });
     postUnpack = "sourceRoot+=/plugins/backend-ekg; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-monitoring.nix
+++ b/nix/.stack.nix/lobemo-backend-monitoring.nix
@@ -114,8 +114,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "dd30455144e11efb435619383ba84ce02aee720d";
-      sha256 = "1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5";
+      rev = "49b347d892d82dce23eb692722649cd8a1149406";
+      sha256 = "0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6";
       });
     postUnpack = "sourceRoot+=/plugins/backend-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -76,8 +76,6 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
         "test-network-mux" = {
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
-            (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
-            (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
             (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
             (hsPkgs."io-sim" or (buildDepError "io-sim"))
             (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
@@ -105,8 +103,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "a43961c1133b9e1b0826f3d4d1bc5b93819037d6";
-      sha256 = "0pj3jnc8wmyx91r22idmkz4jw3mayady4c4wxy45w0lhgksr89x3";
+      rev = "5f77e24c2263560ad58b9ba092c8cfed174675ae";
+      sha256 = "00bm1fa83lc6jgh36mwr4zymzg9hvmq68y2hm4klk8c8gn7vwqqb";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -58,10 +58,10 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
-          (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
           (hsPkgs."network-mux" or (buildDepError "network-mux"))
           (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
-          (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
+          (hsPkgs."ouroboros-network-framework" or (buildDepError "ouroboros-network-framework"))
+          (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
           (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
           (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
           (hsPkgs."bifunctors" or (buildDepError "bifunctors"))
@@ -250,8 +250,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "a43961c1133b9e1b0826f3d4d1bc5b93819037d6";
-      sha256 = "0pj3jnc8wmyx91r22idmkz4jw3mayady4c4wxy45w0lhgksr89x3";
+      rev = "5f77e24c2263560ad58b9ba092c8cfed174675ae";
+      sha256 = "00bm1fa83lc6jgh36mwr4zymzg9hvmq68y2hm4klk8c8gn7vwqqb";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network-framework.nix
+++ b/nix/.stack.nix/ouroboros-network-framework.nix
@@ -41,46 +41,59 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
-      specVersion = "2.0";
-      identifier = { name = "lobemo-scribe-systemd"; version = "0.1.0.0"; };
+      specVersion = "1.10";
+      identifier = {
+        name = "ouroboros-network-framework";
+        version = "0.1.0.0";
+        };
       license = "Apache-2.0";
-      copyright = "2019 IOHK";
-      maintainer = "operations@iohk.io";
-      author = "Alexander Diemand";
-      homepage = "https://github.com/input-output-hk/iohk-monitoring-framework";
+      copyright = "2019 Input Output (Hong Kong) Ltd.";
+      maintainer = "alex@well-typed.com, duncan@well-typed.com, marcin.szamotulski@iohk.io";
+      author = "Alexander Vieth, Duncan Coutts, Marcin Szamotulski";
+      homepage = "";
       url = "";
-      synopsis = "provides a backend for logging to systemd/journal";
+      synopsis = "";
       description = "";
       buildType = "Simple";
       isLocal = true;
       };
     components = {
       "library" = {
-        depends = ([
+        depends = [
           (hsPkgs."base" or (buildDepError "base"))
-          (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
-          (hsPkgs."aeson" or (buildDepError "aeson"))
           (hsPkgs."bytestring" or (buildDepError "bytestring"))
-          (hsPkgs."katip" or (buildDepError "katip"))
-          (hsPkgs."text" or (buildDepError "text"))
-          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
-          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
-          ] ++ (if system.isWindows
-          then [ (hsPkgs."Win32" or (buildDepError "Win32")) ]
-          else [
-            (hsPkgs."unix" or (buildDepError "unix"))
-            ])) ++ (pkgs.lib).optionals (system.isLinux) [
-          (hsPkgs."hsyslog" or (buildDepError "hsyslog"))
-          (hsPkgs."libsystemd-journal" or (buildDepError "libsystemd-journal"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+          (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
+          (hsPkgs."serialise" or (buildDepError "serialise"))
+          (hsPkgs."typed-protocols-examples" or (buildDepError "typed-protocols-examples"))
           ];
         buildable = true;
+        };
+      tests = {
+        "ouroboros-network-framework-tests" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+            (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
+            (hsPkgs."typed-protocols-examples" or (buildDepError "typed-protocols-examples"))
+            (hsPkgs."ouroboros-network-framework" or (buildDepError "ouroboros-network-framework"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            ];
+          buildable = true;
+          };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "49b347d892d82dce23eb692722649cd8a1149406";
-      sha256 = "0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6";
+      url = "https://github.com/input-output-hk/ouroboros-network";
+      rev = "5f77e24c2263560ad58b9ba092c8cfed174675ae";
+      sha256 = "00bm1fa83lc6jgh36mwr4zymzg9hvmq68y2hm4klk8c8gn7vwqqb";
       });
-    postUnpack = "sourceRoot+=/plugins/scribe-systemd; echo source root reset to \$sourceRoot";
+    postUnpack = "sourceRoot+=/ouroboros-network-framework; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -39,7 +39,7 @@ let
       '';
 in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = { asserts = false; ipv6 = false; cddl = false; };
+    flags = { asserts = false; ipv6 = false; cddl = true; };
     package = {
       specVersion = "1.10";
       identifier = { name = "ouroboros-network"; version = "0.1.0.0"; };
@@ -60,7 +60,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."base" or (buildDepError "base"))
           (hsPkgs."network-mux" or (buildDepError "network-mux"))
           (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
-          (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
+          (hsPkgs."ouroboros-network-framework" or (buildDepError "ouroboros-network-framework"))
           (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
           (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
           (hsPkgs."async" or (buildDepError "async"))
@@ -103,7 +103,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."io-sim" or (buildDepError "io-sim"))
             (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
             (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
-            (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
+            (hsPkgs."ouroboros-network-framework" or (buildDepError "ouroboros-network-framework"))
             (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
             ];
           buildable = true;
@@ -120,14 +120,15 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."directory" or (buildDepError "directory"))
             (hsPkgs."network-mux" or (buildDepError "network-mux"))
             (hsPkgs."network" or (buildDepError "network"))
+            (hsPkgs."ouroboros-network-framework" or (buildDepError "ouroboros-network-framework"))
             (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
             (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
             (hsPkgs."random" or (buildDepError "random"))
             (hsPkgs."serialise" or (buildDepError "serialise"))
             (hsPkgs."splitmix" or (buildDepError "splitmix"))
             (hsPkgs."stm" or (buildDepError "stm"))
-            (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
             (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
+            (hsPkgs."typed-protocols-examples" or (buildDepError "typed-protocols-examples"))
             ];
           buildable = true;
           };
@@ -169,8 +170,9 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."tasty" or (buildDepError "tasty"))
             (hsPkgs."text" or (buildDepError "text"))
             (hsPkgs."time" or (buildDepError "time"))
-            (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
             (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
+            (hsPkgs."typed-protocols-examples" or (buildDepError "typed-protocols-examples"))
+            (hsPkgs."ouroboros-network-framework" or (buildDepError "ouroboros-network-framework"))
             (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
             (hsPkgs."ouroboros-protocol-tests" or (buildDepError "ouroboros-protocol-tests"))
             ];
@@ -198,20 +200,21 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."tasty" or (buildDepError "tasty"))
             (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
             (hsPkgs."text" or (buildDepError "text"))
-            (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
             (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
+            (hsPkgs."typed-protocols-examples" or (buildDepError "typed-protocols-examples"))
+            (hsPkgs."ouroboros-network-framework" or (buildDepError "ouroboros-network-framework"))
             (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
             (hsPkgs."ouroboros-protocol-tests" or (buildDepError "ouroboros-protocol-tests"))
             ];
-          buildable = if !flags.cddl then false else true;
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "a43961c1133b9e1b0826f3d4d1bc5b93819037d6";
-      sha256 = "0pj3jnc8wmyx91r22idmkz4jw3mayady4c4wxy45w0lhgksr89x3";
+      rev = "5f77e24c2263560ad58b9ba092c8cfed174675ae";
+      sha256 = "00bm1fa83lc6jgh36mwr4zymzg9hvmq68y2hm4klk8c8gn7vwqqb";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -118,8 +118,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "f27e8b66a393f0b7da1893889dcea07da0fe4dec";
-      sha256 = "1f1r1vidnlyka800jpm9z2myrggasqyzw0aw97q8vw81sh72l51s";
+      rev = "318f5a1594a23aedadb3977ddd5a32230c8be4fe";
+      sha256 = "09zmg09v6r9jr1jl2xim29nc8g4ys2pjisbm66xj2409znn5n19q";
       });
     postUnpack = "sourceRoot+=/byron/semantics/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/tracer-transformers.nix
+++ b/nix/.stack.nix/tracer-transformers.nix
@@ -88,8 +88,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "dd30455144e11efb435619383ba84ce02aee720d";
-      sha256 = "1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5";
+      rev = "49b347d892d82dce23eb692722649cd8a1149406";
+      sha256 = "0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6";
       });
     postUnpack = "sourceRoot+=/tracer-transformers; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-examples.nix
+++ b/nix/.stack.nix/typed-protocols-examples.nix
@@ -41,46 +41,55 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
-      specVersion = "2.0";
-      identifier = { name = "lobemo-scribe-systemd"; version = "0.1.0.0"; };
+      specVersion = "1.10";
+      identifier = { name = "typed-protocols-examples"; version = "0.1.0.0"; };
       license = "Apache-2.0";
-      copyright = "2019 IOHK";
-      maintainer = "operations@iohk.io";
-      author = "Alexander Diemand";
-      homepage = "https://github.com/input-output-hk/iohk-monitoring-framework";
+      copyright = "2019 Input Output (Hong Kong) Ltd.";
+      maintainer = "alex@well-typed.com, duncan@well-typed.com, marcin.szamotulski@iohk.io";
+      author = "Alexander Vieth, Duncan Coutts, Marcin Szamotulski";
+      homepage = "";
       url = "";
-      synopsis = "provides a backend for logging to systemd/journal";
+      synopsis = "Examples and tests for the typed-protocols framework";
       description = "";
       buildType = "Simple";
       isLocal = true;
       };
     components = {
       "library" = {
-        depends = ([
+        depends = [
           (hsPkgs."base" or (buildDepError "base"))
-          (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
-          (hsPkgs."aeson" or (buildDepError "aeson"))
           (hsPkgs."bytestring" or (buildDepError "bytestring"))
-          (hsPkgs."katip" or (buildDepError "katip"))
-          (hsPkgs."text" or (buildDepError "text"))
-          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
-          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
-          ] ++ (if system.isWindows
-          then [ (hsPkgs."Win32" or (buildDepError "Win32")) ]
-          else [
-            (hsPkgs."unix" or (buildDepError "unix"))
-            ])) ++ (pkgs.lib).optionals (system.isLinux) [
-          (hsPkgs."hsyslog" or (buildDepError "hsyslog"))
-          (hsPkgs."libsystemd-journal" or (buildDepError "libsystemd-journal"))
+          (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+          (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
           ];
         buildable = true;
+        };
+      tests = {
+        "typed-protocols-tests" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
+            (hsPkgs."typed-protocols-examples" or (buildDepError "typed-protocols-examples"))
+            (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+            (hsPkgs."io-sim" or (buildDepError "io-sim"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."time" or (buildDepError "time"))
+            ];
+          buildable = true;
+          };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "49b347d892d82dce23eb692722649cd8a1149406";
-      sha256 = "0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6";
+      url = "https://github.com/input-output-hk/ouroboros-network";
+      rev = "5f77e24c2263560ad58b9ba092c8cfed174675ae";
+      sha256 = "00bm1fa83lc6jgh36mwr4zymzg9hvmq68y2hm4klk8c8gn7vwqqb";
       });
-    postUnpack = "sourceRoot+=/plugins/scribe-systemd; echo source root reset to \$sourceRoot";
+    postUnpack = "sourceRoot+=/typed-protocols-examples; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -65,28 +65,12 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           ];
         buildable = true;
         };
-      tests = {
-        "test-protocols" = {
-          depends = [
-            (hsPkgs."base" or (buildDepError "base"))
-            (hsPkgs."bytestring" or (buildDepError "bytestring"))
-            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
-            (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
-            (hsPkgs."io-sim" or (buildDepError "io-sim"))
-            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
-            (hsPkgs."tasty" or (buildDepError "tasty"))
-            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
-            (hsPkgs."time" or (buildDepError "time"))
-            ];
-          buildable = true;
-          };
-        };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "a43961c1133b9e1b0826f3d4d1bc5b93819037d6";
-      sha256 = "0pj3jnc8wmyx91r22idmkz4jw3mayady4c4wxy45w0lhgksr89x3";
+      rev = "5f77e24c2263560ad58b9ba092c8cfed174675ae";
+      sha256 = "00bm1fa83lc6jgh36mwr4zymzg9hvmq68y2hm4klk8c8gn7vwqqb";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/fa7a16291d3e93b068d9b13620fc81c88b5600f0/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/57fcc83702b91e0a7aecdb32c99ab1d8c1c444d0/snapshot.yaml
 compiler: ghc-8.6.5
 
 allow-newer: true
@@ -33,7 +33,7 @@ extra-deps:
   - persistent-template-2.8.2.3
   - prometheus-2.1.2
   - pvss-0.2.0
-  - tasty-hedgehog-1.0.0.1
+  - tasty-hedgehog-1.0.0.2
   - text-zipper-0.10.1
   - time-units-1.0.0
   - word-wrap-0.4.1
@@ -58,7 +58,7 @@ extra-deps:
       - cardano-shell
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: fa7a16291d3e93b068d9b13620fc81c88b5600f0
+    commit: 57fcc83702b91e0a7aecdb32c99ab1d8c1c444d0
     subdirs:
       - .
       - test
@@ -79,7 +79,7 @@ extra-deps:
       - tracer-transformers
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 3c2791584d3f43aa18e9cc13c490239b4c3dcbd2
+    commit: a7b403c1762a6a122a691df816c26563b7e547f8
     subdirs:
       - binary
       - binary/test
@@ -97,7 +97,7 @@ extra-deps:
       - byron/chain/executable-spec
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 86f0cb4705f46307e4c89e7ef4c90142882cce54
+    commit: 172b49ff1b6456851f10ae18f920fbfa733be0b0
     subdirs:
       - cardano-ledger
       - cardano-ledger/test

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/00487726c4bc21b4744e59d913334ebfeac7d68e/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/fa7a16291d3e93b068d9b13620fc81c88b5600f0/snapshot.yaml
 compiler: ghc-8.6.5
 
 allow-newer: true
@@ -58,7 +58,7 @@ extra-deps:
       - cardano-shell
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 00487726c4bc21b4744e59d913334ebfeac7d68e
+    commit: fa7a16291d3e93b068d9b13620fc81c88b5600f0
     subdirs:
       - .
       - test
@@ -67,7 +67,7 @@ extra-deps:
     commit: 43a036c5bbe68ca2e9cbe611eab7982e2348fe49
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: dd30455144e11efb435619383ba84ce02aee720d
+    commit: 49b347d892d82dce23eb692722649cd8a1149406
     subdirs:
       - contra-tracer
       - iohk-monitoring
@@ -79,7 +79,7 @@ extra-deps:
       - tracer-transformers
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 965b8b143632faea16680a195e6de57091382700
+    commit: 3c2791584d3f43aa18e9cc13c490239b4c3dcbd2
     subdirs:
       - binary
       - binary/test
@@ -90,14 +90,14 @@ extra-deps:
     commit: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: f27e8b66a393f0b7da1893889dcea07da0fe4dec
+    commit: 318f5a1594a23aedadb3977ddd5a32230c8be4fe
     subdirs:
       - byron/semantics/executable-spec
       - byron/ledger/executable-spec
       - byron/chain/executable-spec
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: c62e2eeba5756898cbf59732fccd6a83a4065c18
+    commit: 86f0cb4705f46307e4c89e7ef4c90142882cce54
     subdirs:
       - cardano-ledger
       - cardano-ledger/test
@@ -105,7 +105,7 @@ extra-deps:
       - crypto/test
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: a43961c1133b9e1b0826f3d4d1bc5b93819037d6
+    commit: 5f77e24c2263560ad58b9ba092c8cfed174675ae
     subdirs:
       - io-sim
       - io-sim-classes
@@ -113,4 +113,5 @@ extra-deps:
       - ouroboros-network
       - ouroboros-consensus
       - typed-protocols
-      - typed-protocols-cbor
+      - ouroboros-network-framework
+      - typed-protocols-examples


### PR DESCRIPTION
The most significant change comes from a change in the consensus lib's representation of the block number at the genesis. It now uses WithOrigin BlockNo to represent the fact that the genesis itself does not have a block number.

Also one small bug fix: Fix `getCurrentTipBlockNo` to return the block number

It was accidentally using the slot number. This was not all that significant because the only thing it was being used for was to determine how much pipelining to do in the local protocol communicating
with the node.

And one small refactoring:  Minor type clarification: use Tip type

The plugin API for inserting a block takes a block and the server's current tip block number. But since it uses the types ByronBlock and BlockNo, it's not immediately clear that this is the BlockNo of the tip rather than a plausible first guess which is that it's the block number of te block being inserted.

To avoid this danger of confusion, switch the type from BlockNo to the type Tip ByronBlock. Then the type makes clear that it is the tip and not about the block itself. It is of course still possible to get the block number from the tip.

